### PR TITLE
Added in generate_keys in the __init__ to prepare for _perform_refresh

### DIFF
--- a/google/cloud/sql/connector/InstanceConnectionManager.py
+++ b/google/cloud/sql/connector/InstanceConnectionManager.py
@@ -17,11 +17,11 @@ limitations under the License.
 import asyncio
 import googleapiclient
 import googleapiclient.discovery
+from googleapiclient.discovery import Resource
 import google.auth
 from google.auth.credentials import Credentials
-from typing import Dict, Union
-from googleapiclient.discovery import Resource
 from google.cloud.sql.connector.utils import generate_keys
+from typing import Dict, Union
 
 
 class CloudSQLConnectionError(Exception):

--- a/google/cloud/sql/connector/InstanceConnectionManager.py
+++ b/google/cloud/sql/connector/InstanceConnectionManager.py
@@ -21,6 +21,7 @@ import google.auth
 from google.auth.credentials import Credentials
 from typing import Dict, Union
 from googleapiclient.discovery import Resource
+from google.cloud.sql.connector.utils import generate_keys
 
 
 class CloudSQLConnectionError(Exception):
@@ -77,6 +78,7 @@ class InstanceConnectionManager:
             )
 
         self._auth_init()
+        self._priv_key, self._pub_key = generate_keys()
 
         # set current to future InstanceMetadata
         # set next to the future future InstanceMetadata


### PR DESCRIPTION
The purpose of this PR is to make sure the public and private keys are generated when the `InstanceConnectionManager` is initialized.