### PR TITLE
fix: use temporary directory instead of tempfile for Windows compatibility

### DIFF
--- a/google/cloud/sql/connector/instance_connection_manager.py
+++ b/google/cloud/sql/connector/instance_connection_manager.py
@@ -79,6 +79,9 @@ class InstanceMetadata:
         self.ip_address = ip_address
         self.context = ConnectionSSLContext()
 
+        # tmpdir and its contents are automatically deleted after the CA cert
+        # and ephemeral cert are loaded into the SSLcontext. The values
+        # need to be written to files in order to be loaded by the SSLContext
         with TemporaryDirectory() as tmpdir:
             ca_filename, cert_filename, key_filename = write_to_file(
                 tmpdir, server_ca_cert, ephemeral_cert, private_key

--- a/google/cloud/sql/connector/instance_connection_manager.py
+++ b/google/cloud/sql/connector/instance_connection_manager.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 # Custom utils import
 from google.cloud.sql.connector.refresh_utils import _get_ephemeral, _get_metadata
+from google.cloud.sql.connector.utils import write_to_file
 from google.cloud.sql.connector.version import __version__ as version
 
 # Importing libraries
@@ -27,12 +28,11 @@ from google.auth.credentials import Credentials
 import google.auth.transport.requests
 import ssl
 import socket
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryDirectory
 from typing import (
     Any,
     Awaitable,
     Coroutine,
-    IO,
     Optional,
     TYPE_CHECKING,
     Union,
@@ -67,9 +67,6 @@ class ConnectionSSLContext(ssl.SSLContext):
 
 class InstanceMetadata:
     ip_address: str
-    _ca_fileobject: IO
-    _cert_fileobject: IO
-    _key_fileobject: IO
     context: ssl.SSLContext
 
     def __init__(
@@ -80,27 +77,14 @@ class InstanceMetadata:
         server_ca_cert: str,
     ) -> None:
         self.ip_address = ip_address
-
-        self._ca_fileobject = NamedTemporaryFile(suffix=".pem")
-        self._cert_fileobject = NamedTemporaryFile(suffix=".pem")
-        self._key_fileobject = NamedTemporaryFile(suffix=".pem")
-
-        # Write each file and reset to beginning
-        # TODO: Write tests on Windows and convert writing of temp
-        # files to be compatible with Windows.
-        self._ca_fileobject.write(server_ca_cert.encode())
-        self._cert_fileobject.write(ephemeral_cert.encode())
-        self._key_fileobject.write(private_key)
-
-        self._ca_fileobject.seek(0)
-        self._cert_fileobject.seek(0)
-        self._key_fileobject.seek(0)
-
         self.context = ConnectionSSLContext()
-        self.context.load_cert_chain(
-            self._cert_fileobject.name, keyfile=self._key_fileobject.name
-        )
-        self.context.load_verify_locations(cafile=self._ca_fileobject.name)
+
+        with TemporaryDirectory() as tmpdir:
+            ca_filename, cert_filename, key_filename = write_to_file(
+                tmpdir, server_ca_cert, ephemeral_cert, private_key
+            )
+            self.context.load_cert_chain(cert_filename, keyfile=key_filename)
+            self.context.load_verify_locations(cafile=ca_filename)
 
 
 class CloudSQLConnectionError(Exception):

--- a/google/cloud/sql/connector/utils.py
+++ b/google/cloud/sql/connector/utils.py
@@ -58,14 +58,22 @@ async def generate_keys() -> Tuple[bytes, str]:
     return priv_key, pub_key
 
 
-def write_to_file(serverCaCert: str, ephemeralCert: str, priv_key: bytes) -> None:
+def write_to_file(
+    dir_path: str, serverCaCert: str, ephemeralCert: str, priv_key: bytes
+) -> Tuple[str, str, str]:
     """
     Helper function to write the serverCaCert, ephemeral certificate and
-    private key to .pem files
+    private key to .pem files in a given directory
     """
-    with open("keys/ca.pem", "w+") as ca_out:
+    ca_filename = f"{dir_path}/ca.pem"
+    cert_filename = f"{dir_path}/cert.pem"
+    key_filename = f"{dir_path}/priv.pem"
+
+    with open(ca_filename, "w+") as ca_out:
         ca_out.write(serverCaCert)
-    with open("keys/cert.pem", "w+") as ephemeral_out:
+    with open(cert_filename, "w+") as ephemeral_out:
         ephemeral_out.write(ephemeralCert)
-    with open("keys/priv.pem", "wb") as priv_out:
+    with open(key_filename, "wb") as priv_out:
         priv_out.write(priv_key)
+
+    return (ca_filename, cert_filename, key_filename)


### PR DESCRIPTION
fixes #22

Replaced the NamedTemporaryFiles with a TemporaryDirectory in which new files are created. When used in a context manager, a TemporaryDirectory and all its contents are deleted once the context is closed ([Python docs](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory))