### PR TITLE
chore: upgrade pytds to latest release version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ aiohttp==3.7.4.post0
 cryptography==3.4.7
 PyMySQL==1.0.2
 pg8000==1.19.3
-# python-tds==1.10.0
-git+https://github.com/denisenkom/pytds.git
+python-tds==1.11.0
 pyopenssl==20.0.1
 Requests==2.25.1
 google-api-python-client==2.3.0

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     extras_require={
         "pymysql": ["PyMySQL==1.0.2"],
         "pg8000": ["pg8000==1.19.3"],
-        "pytds": ["python-tds @ git+https://github.com/denisenkom/pytds.git"]
+        "pytds": ["python-tds==1.11.0"]
     },
     python_requires=">=3.6",
     include_package_data=True,


### PR DESCRIPTION
Version 1.11.0 of pydts was released earlier today so we don't have to pull from GitHub anymore.