### PR TITLE
feat: support Active Directory auth for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ connector.connect(
  )
 ```
 
-### SQL Server Active Directory Authentication (Integrated Security)
+### SQL Server Active Directory Authentication
 Active Directory authentication for SQL Server instances is currently only supported on Windows. First, make sure to follow [these steps](https://cloud.google.com/blog/topics/developers-practitioners/creating-sql-server-instance-integrated-active-directory-using-google-cloud-sql) to set up a Managed AD domain and join your Cloud SQL instance to the domain. [See here for more info on Cloud SQL Active Directory integration](https://cloud.google.com/sql/docs/sqlserver/ad).
 
 Once you have followed the steps linked above, you can run the following code to return a connection object:
@@ -137,7 +137,7 @@ connector.connect(
     "project:region:instance",
     "pytds",
     db="my_database",
-    integrated_security=True,
+    active_directory_auth=True,
     server_name="public.[instance].[location].[project].cloudsql.[domain]",
 )
 ``` 
@@ -147,7 +147,7 @@ connector.connect(
     "project:region:instance",
     "pytds",
     db="my_database",
-    integrated_security=True,
+    active_directory_auth=True,
     server_name="private.[instance].[location].[project].cloudsql.[domain]",
     ip_types=IPTypes.PRIVATE
 )

--- a/README.md
+++ b/README.md
@@ -127,6 +127,32 @@ connector.connect(
      enable_iam_auth=True,
  )
 ```
+
+### SQL Server Active Directory Authentication (Integrated Security)
+Active Directory authentication for SQL Server instances is currently only supported on Windows. First, make sure to follow [these steps](https://cloud.google.com/blog/topics/developers-practitioners/creating-sql-server-instance-integrated-active-directory-using-google-cloud-sql) to set up a Managed AD domain and join your Cloud SQL instance to the domain. [See here for more info on Cloud SQL Active Directory integration](https://cloud.google.com/sql/docs/sqlserver/ad).
+
+Once you have followed the steps linked above, you can run the following code to return a connection object:
+```python
+connector.connect(
+    "project:region:instance",
+    "pytds",
+    db="my_database",
+    integrated_security=True,
+    server_name="public.[instance].[location].[project].cloudsql.[domain]",
+)
+``` 
+Or, if using Private IP:
+```python
+connector.connect(
+    "project:region:instance",
+    "pytds",
+    db="my_database",
+    integrated_security=True,
+    server_name="private.[instance].[location].[project].cloudsql.[domain]",
+    ip_types=IPTypes.PRIVATE
+)
+``` 
+
 ### Setup for development
 
 Tests can be run with `nox`. Change directory into the `cloud-sql-python-connector` and just run `nox` to run the tests.

--- a/google/cloud/sql/connector/instance_connection_manager.py
+++ b/google/cloud/sql/connector/instance_connection_manager.py
@@ -582,9 +582,9 @@ class InstanceConnectionManager:
             socket.create_connection((ip_address, SERVER_PROXY_PORT)),
             server_hostname=ip_address,
         )
-        if kwargs.pop("integrated_security", False):
+        if kwargs.pop("active_directory_auth", False):
             if platform.system() == "Windows":
-                # Ignore username and password if using integrated auth
+                # Ignore username and password if using active directory auth
                 server_name = kwargs.pop("server_name")
                 return pytds.connect(
                     database=db,
@@ -594,7 +594,7 @@ class InstanceConnectionManager:
                 )
             else:
                 raise PlatformNotSupportedError(
-                    "Integrated security is currently only supported on Windows."
+                    "Active Directory authentication is currently only supported on Windows."
                 )
 
         user = kwargs.pop("user")


### PR DESCRIPTION
Add support for Integrated Security (Active Directory auth) for Windows using [SSPI](https://docs.microsoft.com/en-us/windows-server/security/windows-authentication/security-support-provider-interface-architecture). PyTDS offers experimental support for Kerberos auth on non-Windows platforms, but I haven't tested it yet, so for now only Windows will be supported.