### PR TITLE
fix: strip padding from access tokens if present

### DIFF
--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -152,7 +152,7 @@ async def _get_ephemeral(
 
     # TODO: remove this once issue with OAuth2 Tokens is resolved.
     # See https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/issues/137
-    
+
     headers = {
         "Authorization": f"Bearer {credentials.token.rstrip('.')}",
     }

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -150,8 +150,9 @@ async def _get_ephemeral(
         request = google.auth.transport.requests.Request()
         credentials.refresh(request)
 
+    stripped_token = credentials.token.rstrip(".")
     headers = {
-        "Authorization": f"Bearer {credentials.token}",
+        "Authorization": f"Bearer {stripped_token}",
     }
 
     url = "https://www.googleapis.com/sql/{}/projects/{}/instances/{}/createEphemeral".format(

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -150,6 +150,7 @@ async def _get_ephemeral(
         request = google.auth.transport.requests.Request()
         credentials.refresh(request)
 
+    # TODO: remove this once issue with OAuth2 Tokens is resolved.
     stripped_token = credentials.token.rstrip(".")
     headers = {
         "Authorization": f"Bearer {stripped_token}",

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -151,6 +151,7 @@ async def _get_ephemeral(
         credentials.refresh(request)
 
     # TODO: remove this once issue with OAuth2 Tokens is resolved.
+    # See https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/issues/137
     stripped_token = credentials.token.rstrip(".")
     headers = {
         "Authorization": f"Bearer {stripped_token}",

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -152,9 +152,9 @@ async def _get_ephemeral(
 
     # TODO: remove this once issue with OAuth2 Tokens is resolved.
     # See https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/issues/137
-    stripped_token = credentials.token.rstrip(".")
+    
     headers = {
-        "Authorization": f"Bearer {stripped_token}",
+        "Authorization": f"Bearer {credentials.token.rstrip('.')}",
     }
 
     url = "https://www.googleapis.com/sql/{}/projects/{}/instances/{}/createEphemeral".format(


### PR DESCRIPTION
Strips trailing `.` characters from access tokens
fixes #137 