### PR TITLE
chore: update error message and replace deprecated logger.warn method

### DIFF
--- a/google/cloud/sql/connector/instance_connection_manager.py
+++ b/google/cloud/sql/connector/instance_connection_manager.py
@@ -389,7 +389,7 @@ class InstanceConnectionManager:
             except Exception as e:
                 logger.exception(
                     "An error occurred while performing refresh. Retrying in 60s.",
-                    exc_info=e
+                    exc_info=e,
                 )
                 instance_data = None
                 try:

--- a/google/cloud/sql/connector/instance_connection_manager.py
+++ b/google/cloud/sql/connector/instance_connection_manager.py
@@ -387,9 +387,9 @@ class InstanceConnectionManager:
             try:
                 task.result()
             except Exception as e:
-                logger.warn(
-                    "An error occurred while performing refresh. Retrying immediately.",
-                    e,
+                logger.exception(
+                    "An error occurred while performing refresh. Retrying in 60s.",
+                    exc_info=e
                 )
                 instance_data = None
                 try:


### PR DESCRIPTION
Noticed an error in the logs that said that the "warn" method was deprecated, and `logger.exception` is probably more appropriate here anyway.