### PR TITLE
fix: update locks to be thread-safe

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -17,3 +17,6 @@ ignore_missing_imports = True
 
 [mypy-OpenSSL]
 ignore_missing_imports = True
+
+[mypy-async_generator]
+ignore_missing_imports = True

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -126,7 +126,7 @@ class Connector:
         if "ip_types" in kwargs:
             ip_type = kwargs.pop("ip_types")
             logger.warning(
-                "Deprecation Warning: Parameter `ip_types` is deprecated and may be removed"
+                "Deprecation Warning: Parameter `ip_types` is deprecated and may be removed "
                 "in a future release. Please use `ip_type` instead."
             )
         else:

--- a/google/cloud/sql/connector/instance_connection_manager.py
+++ b/google/cloud/sql/connector/instance_connection_manager.py
@@ -24,6 +24,7 @@ from google.cloud.sql.connector.version import __version__ as version
 import asyncio
 import aiohttp
 import concurrent
+import threading
 import datetime
 from enum import Enum
 import google.auth
@@ -233,7 +234,7 @@ class InstanceConnectionManager:
     _project: str
     _region: str
 
-    _refresh_in_progress: asyncio.locks.Event
+    _refresh_in_progress: threading.Event
     _current: asyncio.Task  # task wraps coroutine that returns InstanceMetadata
     _next: asyncio.Task  # task wraps coroutine that returns another task
 
@@ -280,7 +281,7 @@ class InstanceConnectionManager:
 
         async def _set_instance_data() -> None:
             logger.debug("Updating instance data")
-            self._refresh_in_progress = asyncio.locks.Event()
+            self._refresh_in_progress = threading.Event()
             self._current = self._loop.create_task(self._get_instance_data())
             self._next = self._loop.create_task(self._schedule_refresh())
 

--- a/google/cloud/sql/connector/rate_limiter.py
+++ b/google/cloud/sql/connector/rate_limiter.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import asyncio
+import threading
 
 
 class AsyncRateLimiter(object):
@@ -46,7 +47,7 @@ class AsyncRateLimiter(object):
         self.rate = rate
         self.max_capacity = max_capacity
         self._loop = loop or asyncio.get_event_loop()
-        self._lock = asyncio.Lock()
+        self._lock = threading.Lock()
         self._tokens: float = max_capacity
         self._last_token_update = self._loop.time()
 

--- a/google/cloud/sql/connector/rate_limiter.py
+++ b/google/cloud/sql/connector/rate_limiter.py
@@ -16,10 +16,11 @@ limitations under the License.
 import asyncio
 import concurrent.futures
 import threading
+from typing import AsyncGenerator
 
 # python 3.6 does not have support for contextlib.asynccontextmanager
 try:
-    from contextlib import asynccontextmanager
+    from contextlib import asynccontextmanager  # type: ignore
 except ImportError:
     from async_generator import asynccontextmanager
 
@@ -82,7 +83,7 @@ class AsyncRateLimiter(object):
             await asyncio.sleep(wait_time)
 
     @asynccontextmanager
-    async def async_lock(self, lock: threading.Lock) -> None:
+    async def async_lock(self, lock: threading.Lock) -> AsyncGenerator:
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:

--- a/google/cloud/sql/connector/rate_limiter.py
+++ b/google/cloud/sql/connector/rate_limiter.py
@@ -18,6 +18,7 @@ import concurrent.futures
 import threading
 import contextlib
 
+
 class AsyncRateLimiter(object):
     """
     An asyncio-compatible rate limiter which uses the Token Bucket algorithm
@@ -75,16 +76,17 @@ class AsyncRateLimiter(object):
             wait_time = token_deficit / self.rate
             await asyncio.sleep(wait_time)
 
-
     @contextlib.asynccontextmanager
-    async def async_lock(self, lock) -> None:
-        loop = asyncio.get_event_loop()
+    async def async_lock(self, lock: threading.Lock) -> None:
+        try:
+            loop = asyncio.get_event_loop()
+        except:
+            loop = asyncio.new_event_loop()
         await loop.run_in_executor(self._pool, lock.acquire)
         try:
             yield  # the lock is held
         finally:
             lock.release()
-
 
     async def acquire(self) -> None:
         """

--- a/google/cloud/sql/connector/rate_limiter.py
+++ b/google/cloud/sql/connector/rate_limiter.py
@@ -16,7 +16,12 @@ limitations under the License.
 import asyncio
 import concurrent.futures
 import threading
-import contextlib
+
+# python 3.6 does not have support for contextlib.asynccontextmanager
+try:
+    from contextlib import asynccontextmanager
+except ImportError:
+    from async_generator import asynccontextmanager
 
 
 class AsyncRateLimiter(object):
@@ -76,11 +81,11 @@ class AsyncRateLimiter(object):
             wait_time = token_deficit / self.rate
             await asyncio.sleep(wait_time)
 
-    @contextlib.asynccontextmanager
+    @asynccontextmanager
     async def async_lock(self, lock: threading.Lock) -> None:
         try:
             loop = asyncio.get_event_loop()
-        except:
+        except RuntimeError:
             loop = asyncio.new_event_loop()
         await loop.run_in_executor(self._pool, lock.acquire)
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-tds==1.11.0
 pyopenssl==21.0.0
 Requests==2.27.1
 google-api-python-client==2.35.0
+async_generator==1.10; python_version == '3.6'

--- a/tests/system/test_connector_object.py
+++ b/tests/system/test_connector_object.py
@@ -89,7 +89,8 @@ def test_connector_in_ThreadPoolExecutor() -> None:
     This helps simulate how connector works in Cloud Run and Cloud Functions.
     """
 
-    def threaded_connector() -> datetime.datetime:
+    def get_time() -> datetime.datetime:
+        """Helper method for getting current time from database."""
         default_connector = connector.Connector()
         pool = init_connection_engine(default_connector)
 
@@ -100,6 +101,6 @@ def test_connector_in_ThreadPoolExecutor() -> None:
 
     # try running connector in ThreadPoolExecutor as Cloud Run does
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        future = executor.submit(threaded_connector)
+        future = executor.submit(get_time)
         return_value = future.result()
         assert isinstance(return_value, datetime.datetime)

--- a/tests/system/test_connector_object.py
+++ b/tests/system/test_connector_object.py
@@ -98,7 +98,7 @@ def test_connector_in_ThreadPoolExecutor() -> None:
             current_time = conn.execute("SELECT NOW()").fetchone()
         return current_time[0]
 
-    # try running connector in threadPoolExectutor as Cloud Run does
+    # try running connector in ThreadPoolExecutor as Cloud Run does
     with concurrent.futures.ThreadPoolExecutor() as executor:
         future = executor.submit(threaded_connector)
         return_value = future.result()


### PR DESCRIPTION
Current locking code `asyncio.Lock()` is not thread-safe and needs to be replaced with `threading.Lock()`