### PR TITLE
chore: add check to InstanceConnectionManager.close()

### DIFF
--- a/google/cloud/sql/connector/instance_connection_manager.py
+++ b/google/cloud/sql/connector/instance_connection_manager.py
@@ -668,9 +668,11 @@ class InstanceConnectionManager:
         """Cleanup function to make sure ClientSession is closed and tasks have
         finished to have a graceful exit.
         """
-        logger.debug("Waiting for _current to be cancelled")
-        self._current.cancel()
-        logger.debug("Waiting for _next to be cancelled")
-        self._next.cancel()
+        if hasattr(self, "_current"):
+            logger.debug("Waiting for _current to be cancelled")
+            self._current.cancel()
+        if hasattr(self, "_next"):
+            logger.debug("Waiting for _next to be cancelled")
+            self._next.cancel()
         logger.debug("Waiting for _client_session to close")
         await self._client_session.close()


### PR DESCRIPTION
Clean's up additional exception where if InstanceConnectionManager's `__init__` fails prior to creating and setting the current and next attributes (i.e. if initializing credentials has an error etc) then the Connector destructor will fail to cleanup and throw additional error as it will try to cancel tasks that don't exist. 