### PR TITLE
chore: refactor refresh methods

### DIFF
--- a/google/cloud/sql/connector/instance_connection_manager.py
+++ b/google/cloud/sql/connector/instance_connection_manager.py
@@ -122,7 +122,7 @@ class ExpiredInstanceMetadata(Exception):
     """
 
     def __init__(self, *args: Any) -> None:
-        super(CredentialsTypeError, self).__init__(self, *args)
+        super(ExpiredInstanceMetadata, self).__init__(self, *args)
 
 
 class InstanceMetadata:
@@ -449,10 +449,11 @@ class InstanceConnectionManager:
             A coroutine that sleeps for the specified amount of time before
             running _perform_refresh.
             """
-            refresh_task = None
+            refresh_task: asyncio.Task
             try:
                 logger.debug("Entering sleep")
-                await asyncio.sleep(delay)
+                if delay > 0:
+                    await asyncio.sleep(delay)
                 refresh_task = self._loop.create_task(self._perform_refresh())
                 await refresh_task
             except asyncio.CancelledError as e:

--- a/google/cloud/sql/connector/instance_connection_manager.py
+++ b/google/cloud/sql/connector/instance_connection_manager.py
@@ -443,7 +443,7 @@ class InstanceConnectionManager:
             # bad refresh attempt
             except Exception as e:
                 logger.exception(
-                    "An error occurred while performing refresh."
+                    "An error occurred while performing refresh. "
                     "Scheduling another refresh attempt immediately",
                     exc_info=e,
                 )

--- a/google/cloud/sql/connector/instance_connection_manager.py
+++ b/google/cloud/sql/connector/instance_connection_manager.py
@@ -408,6 +408,7 @@ class InstanceConnectionManager:
                     expiration = token_expiration
 
         except Exception as e:
+            logger.debug("Error occurred during _perform_refresh.")
             raise e
 
         finally:

--- a/google/cloud/sql/connector/instance_connection_manager.py
+++ b/google/cloud/sql/connector/instance_connection_manager.py
@@ -438,7 +438,6 @@ class InstanceConnectionManager:
                 await asyncio.sleep(delay)
                 await refresh_task
             except asyncio.CancelledError as e:
-                print("Cancel called!")
                 logger.debug("Schedule refresh task cancelled.")
                 raise e
             # bad refresh attempt
@@ -448,7 +447,6 @@ class InstanceConnectionManager:
                     "Scheduling another refresh attempt immediately",
                     exc_info=e,
                 )
-                print("bad refresh!")
                 # check if current metadata is valid, don't want to replace valid metadata with invalid one
                 instance_data = None
                 try:

--- a/tests/unit/test_instance_connection_manager.py
+++ b/tests/unit/test_instance_connection_manager.py
@@ -42,6 +42,10 @@ async def _get_metadata_success(*args: Any, **kwargs: Any) -> MockMetadata:
     return MockMetadata(datetime.datetime.now() + datetime.timedelta(minutes=10))
 
 
+async def _get_metadata_expired(*args: Any, **kwargs: Any) -> MockMetadata:
+    return MockMetadata(datetime.datetime.now() - datetime.timedelta(minutes=10))
+
+
 async def _get_metadata_error(*args: Any, **kwargs: Any) -> None:
     raise BadRefresh("something went wrong...")
 

--- a/tests/unit/test_instance_connection_manager.py
+++ b/tests/unit/test_instance_connection_manager.py
@@ -222,21 +222,18 @@ async def test_force_refresh_cancels_pending_refresh(
     # allow more frequent refreshes for tests
     setattr(icm, "_refresh_rate_limiter", test_rate_limiter)
 
-    # stub _get_instance_data to return a MockMetadata instance
+    # stub _perform_refresh to return a MockMetadata instance
     setattr(icm, "_perform_refresh", _get_metadata_success)
-
-    # set _current to MockMetadata
-    icm._current = asyncio.run_coroutine_threadsafe(
-        icm._perform_refresh(), icm._loop
-    ).result(timeout=10)
-
+    print("ICM next: ", icm._next)
     # since the pending refresh isn't for another 55 min, the refresh_in_progress event
     # shouldn't be set
     pending_refresh = icm._next
+
     assert icm._refresh_in_progress.is_set() is False
 
     icm.force_refresh()
 
+    print(pending_refresh)
     assert pending_refresh.cancelled() is True
     assert isinstance(icm._current.result(), MockMetadata)
 

--- a/tests/unit/test_instance_connection_manager.py
+++ b/tests/unit/test_instance_connection_manager.py
@@ -154,6 +154,8 @@ async def test_schedule_refresh_replaces_result(
     assert icm._current.result() == refresh_metadata
     assert old_metadata != icm._current.result()
     assert isinstance(icm._current.result(), MockMetadata)
+    # cleanup icm
+    asyncio.run_coroutine_threadsafe(icm.close(), icm._loop).result(timeout=5)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_refresh_utils.py
+++ b/tests/unit/test_refresh_utils.py
@@ -223,8 +223,9 @@ async def test_is_valid_with_valid_metadata() -> None:
     """
     Test to check that valid metadata with expiration in future returns True.
     """
+    loop = asyncio.get_event_loop()
     # task that returns class with expiration 10 mins in future
-    task = asyncio.create_task(_get_metadata_success())
+    task = loop.create_task(_get_metadata_success())
     assert await _is_valid(task)
 
 
@@ -234,6 +235,7 @@ async def test_is_valid_with_expired_metadata() -> None:
     """
     Test to check that invalid metadata with expiration in past returns False.
     """
+    loop = asyncio.get_event_loop()
     # task that returns class with expiration 10 mins in past
-    task = asyncio.create_task(_get_metadata_expired())
+    task = loop.create_task(_get_metadata_expired())
     assert not await _is_valid(task)


### PR DESCRIPTION
Refactor refresh methods to match those of the [Cloud SQL Go Connector](https://github.com/GoogleCloudPlatform/cloud-sql-go-connector).

Separate PR will make refresh methods into static methods within `refresh_utils.py`