### PR TITLE
chore: remove unused google-api-python-client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ pg8000==1.24.1
 python-tds==1.11.0
 pyopenssl==22.0.0
 Requests==2.27.1
-google-api-python-client==2.41.0
 google-auth==2.6.2


### PR DESCRIPTION
Because we create aiohttp calls directly we are no longer using google-api-python-client