### PR TITLE
chore: update InstanceConnectionManager to Instance

### DIFF
--- a/google/cloud/sql/connector/__init__.py
+++ b/google/cloud/sql/connector/__init__.py
@@ -17,7 +17,7 @@ limitations under the License.
 from typing import List
 
 from .connector import connect, Connector
-from .instance_connection_manager import IPTypes
+from .instance import IPTypes
 
 
 __ALL__ = [connect, Connector, IPTypes]

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -158,9 +158,9 @@ class InstanceMetadata:
         )
 
 
-class InstanceConnectionManager:
-    """A class to manage the details of the connection, including refreshing the
-    credentials.
+class Instance:
+    """A class to manage the details of the connection to a Cloud SQL
+    instance, including refreshing the credentials.
 
     :param instance_connection_string:
         The Google Cloud SQL Instance's connection
@@ -388,9 +388,7 @@ class InstanceConnectionManager:
         :returns: A Task representing the scheduled _perform_refresh.
         """
 
-        async def _refresh_task(
-            self: InstanceConnectionManager, delay: int
-        ) -> InstanceMetadata:
+        async def _refresh_task(self: Instance, delay: int) -> InstanceMetadata:
             """
             A coroutine that sleeps for the specified amount of time before
             running _perform_refresh.

--- a/google/cloud/sql/connector/pytds.py
+++ b/google/cloud/sql/connector/pytds.py
@@ -2,7 +2,7 @@ import ssl
 import socket
 import platform
 from typing import Any, TYPE_CHECKING
-from google.cloud.sql.connector.instance_connection_manager import (
+from google.cloud.sql.connector.instance import (
     PlatformNotSupportedError,
 )
 

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 import pytest  # noqa F401 Needed to run the tests
-from google.cloud.sql.connector.instance_connection_manager import (
+from google.cloud.sql.connector.instance import (
     IPTypes,
 )
 from google.cloud.sql.connector import connector
@@ -24,7 +24,7 @@ from unittest.mock import patch
 from typing import Any
 
 
-class MockInstanceConnectionManager:
+class MockInstance:
     _enable_iam_auth: bool
 
     def __init__(
@@ -43,7 +43,7 @@ class MockInstanceConnectionManager:
 
 
 async def timeout_stub(*args: Any, **kwargs: Any) -> None:
-    """Timeout stub for InstanceConnectionManager.connect()"""
+    """Timeout stub for Instance.connect()"""
     # sleep 10 seconds
     await asyncio.sleep(10)
 
@@ -52,11 +52,11 @@ def test_connect_timeout() -> None:
     """Test that connection times out after custom timeout."""
     connect_string = "test-project:test-region:test-instance"
 
-    icm = MockInstanceConnectionManager()
+    instance = MockInstance()
     mock_instances = {}
-    mock_instances[connect_string] = icm
-    # stub icm to raise timeout
-    setattr(icm, "connect_info", timeout_stub)
+    mock_instances[connect_string] = instance
+    # stub instance to raise timeout
+    setattr(instance, "connect_info", timeout_stub)
     # set default connector
     default_connector = connector.Connector()
     connector._default_connector = default_connector
@@ -75,10 +75,10 @@ def test_connect_enable_iam_auth_error() -> None:
     """Test that calling connect() with different enable_iam_auth
     argument values throws error."""
     connect_string = "my-project:my-region:my-instance"
-    # create mock ICM with enable_iam_auth=False
-    icm = MockInstanceConnectionManager(enable_iam_auth=False)
+    # create mock instance with enable_iam_auth=False
+    instance = MockInstance(enable_iam_auth=False)
     mock_instances = {}
-    mock_instances[connect_string] = icm
+    mock_instances[connect_string] = instance
     # set default connector
     default_connector = connector.Connector()
     connector._default_connector = default_connector
@@ -91,7 +91,7 @@ def test_connect_enable_iam_auth_error() -> None:
             "pg8000",
             enable_iam_auth=True,
         )
-    # remove mock_icm to avoid destructor warnings
+    # remove mock_instance to avoid destructor warnings
     default_connector._instances = {}
 
 

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -21,8 +21,8 @@ from google.cloud.sql.connector.rate_limiter import AsyncRateLimiter
 from typing import Any
 import pytest  # noqa F401 Needed to run the tests
 from google.auth.credentials import Credentials
-from google.cloud.sql.connector.instance_connection_manager import (
-    InstanceConnectionManager,
+from google.cloud.sql.connector.instance import (
+    Instance,
     CredentialsTypeError,
 )
 from google.cloud.sql.connector.utils import generate_keys
@@ -50,20 +50,20 @@ async def _get_metadata_error(*args: Any, **kwargs: Any) -> None:
 
 
 @pytest.fixture
-def icm(
+def instance(
     fake_credentials: Credentials,
     event_loop: asyncio.AbstractEventLoop,
-) -> InstanceConnectionManager:
+) -> Instance:
     with patch("google.auth.default") as mock_auth:
         mock_auth.return_value = fake_credentials, None
         keys = asyncio.run_coroutine_threadsafe(generate_keys(), event_loop)
-        icm = InstanceConnectionManager(
+        instance = Instance(
             "my-project:my-region:my-instance", "pymysql", keys, event_loop
         )
         # stub _perform_refresh to return a "valid" MockMetadata object
-        setattr(icm, "_perform_refresh", _get_metadata_success)
-        icm._current = icm._schedule_refresh(0)
-    return icm
+        setattr(instance, "_perform_refresh", _get_metadata_success)
+        instance._current = instance._schedule_refresh(0)
+    return instance
 
 
 @pytest.fixture
@@ -72,11 +72,11 @@ def test_rate_limiter(event_loop: asyncio.AbstractEventLoop) -> AsyncRateLimiter
 
 
 @pytest.mark.asyncio
-async def test_InstanceConnectionManager_init(
+async def test_Instance_init(
     fake_credentials: Credentials, event_loop: asyncio.AbstractEventLoop
 ) -> None:
     """
-    Test to check whether the __init__ method of InstanceConnectionManager
+    Test to check whether the __init__ method of Instance
     can tell if the connection string that's passed in is formatted correctly.
     """
 
@@ -84,145 +84,143 @@ async def test_InstanceConnectionManager_init(
     keys = asyncio.run_coroutine_threadsafe(generate_keys(), event_loop)
     with patch("google.auth.default") as mock_auth:
         mock_auth.return_value = fake_credentials, None
-        icm = InstanceConnectionManager(connect_string, "pymysql", keys, event_loop)
-    project_result = icm._project
-    region_result = icm._region
-    instance_result = icm._instance
+        instance = Instance(connect_string, "pymysql", keys, event_loop)
+    project_result = instance._project
+    region_result = instance._region
+    instance_result = instance._instance
     assert (
         project_result == "test-project"
         and region_result == "test-region"
         and instance_result == "test-instance"
     )
-    # cleanup icm
-    await icm.close()
+    # cleanup instance
+    await instance.close()
 
 
 @pytest.mark.asyncio
-async def test_InstanceConnectionManager_init_bad_credentials(
+async def test_Instance_init_bad_credentials(
     event_loop: asyncio.AbstractEventLoop,
 ) -> None:
     """
-    Test to check whether the __init__ method of InstanceConnectionManager
+    Test to check whether the __init__ method of Instance
     throws proper error for bad credentials arg type.
     """
     connect_string = "test-project:test-region:test-instance"
     keys = asyncio.run_coroutine_threadsafe(generate_keys(), event_loop)
     with pytest.raises(CredentialsTypeError):
-        icm = InstanceConnectionManager(
-            connect_string, "pymysql", keys, event_loop, credentials=1
-        )
-        await icm.close()
+        instance = Instance(connect_string, "pymysql", keys, event_loop, credentials=1)
+        await instance.close()
 
 
 @pytest.mark.asyncio
 async def test_schedule_refresh_replaces_result(
-    icm: InstanceConnectionManager, test_rate_limiter: AsyncRateLimiter
+    instance: Instance, test_rate_limiter: AsyncRateLimiter
 ) -> None:
     """
     Test to check whether _schedule_refresh replaces a valid result with another valid result
     """
     # allow more frequent refreshes for tests
-    setattr(icm, "_refresh_rate_limiter", test_rate_limiter)
+    setattr(instance, "_refresh_rate_limiter", test_rate_limiter)
 
     # stub _perform_refresh to return a "valid" MockMetadata object
-    setattr(icm, "_perform_refresh", _get_metadata_success)
+    setattr(instance, "_perform_refresh", _get_metadata_success)
 
-    old_metadata = await icm._current
+    old_metadata = await instance._current
 
     # schedule refresh immediately and await it
-    refresh_task = icm._schedule_refresh(0)
+    refresh_task = instance._schedule_refresh(0)
     refresh_metadata = await refresh_task
 
     # check that current metadata has been replaced with refresh metadata
-    assert icm._current.result() == refresh_metadata
-    assert old_metadata != icm._current.result()
-    assert isinstance(icm._current.result(), MockMetadata)
-    # cleanup icm
-    await icm.close()
+    assert instance._current.result() == refresh_metadata
+    assert old_metadata != instance._current.result()
+    assert isinstance(instance._current.result(), MockMetadata)
+    # cleanup instance
+    await instance.close()
 
 
 @pytest.mark.asyncio
 async def test_schedule_refresh_wont_replace_valid_result_with_invalid(
-    icm: InstanceConnectionManager, test_rate_limiter: AsyncRateLimiter
+    instance: Instance, test_rate_limiter: AsyncRateLimiter
 ) -> None:
     """
     Test to check whether _perform_refresh won't replace a valid _current
     value with an invalid one
     """
     # allow more frequent refreshes for tests
-    setattr(icm, "_refresh_rate_limiter", test_rate_limiter)
+    setattr(instance, "_refresh_rate_limiter", test_rate_limiter)
 
-    await icm._current
-    old_task = icm._current
+    await instance._current
+    old_task = instance._current
 
     # stub _perform_refresh to throw an error
-    setattr(icm, "_perform_refresh", _get_metadata_error)
+    setattr(instance, "_perform_refresh", _get_metadata_error)
 
     # schedule refresh immediately
-    refresh_task = icm._schedule_refresh(0)
+    refresh_task = instance._schedule_refresh(0)
 
     # wait for invalid refresh to finish
     with pytest.raises(BadRefresh):
         assert await refresh_task
 
     # check that invalid refresh did not replace valid current metadata
-    assert icm._current == old_task
-    assert isinstance(icm._current.result(), MockMetadata)
-    await icm.close()
+    assert instance._current == old_task
+    assert isinstance(instance._current.result(), MockMetadata)
+    await instance.close()
 
 
 @pytest.mark.asyncio
 async def test_schedule_refresh_replaces_invalid_result(
-    icm: InstanceConnectionManager, test_rate_limiter: AsyncRateLimiter
+    instance: Instance, test_rate_limiter: AsyncRateLimiter
 ) -> None:
     """
     Test to check whether _perform_refresh will replace an invalid refresh result with
     a valid one
     """
     # allow more frequent refreshes for tests
-    setattr(icm, "_refresh_rate_limiter", test_rate_limiter)
+    setattr(instance, "_refresh_rate_limiter", test_rate_limiter)
 
     # stub _perform_refresh to throw an error
-    setattr(icm, "_perform_refresh", _get_metadata_error)
+    setattr(instance, "_perform_refresh", _get_metadata_error)
 
     # set current to invalid data (error)
-    icm._current = icm._schedule_refresh(0)
+    instance._current = instance._schedule_refresh(0)
 
     # check that current is now invalid (error)
     with pytest.raises(BadRefresh):
-        assert await icm._current
+        assert await instance._current
 
     # stub _perform_refresh to return a valid MockMetadata instance
-    setattr(icm, "_perform_refresh", _get_metadata_success)
+    setattr(instance, "_perform_refresh", _get_metadata_success)
 
     # schedule refresh immediately and await it
-    refresh_task = icm._schedule_refresh(0)
+    refresh_task = instance._schedule_refresh(0)
     refresh_metadata = await refresh_task
 
     # check that current is now valid MockMetadata
-    assert icm._current.result() == refresh_metadata
-    assert isinstance(icm._current.result(), MockMetadata)
-    await icm.close()
+    assert instance._current.result() == refresh_metadata
+    assert isinstance(instance._current.result(), MockMetadata)
+    await instance.close()
 
 
 @pytest.mark.asyncio
 async def test_force_refresh_cancels_pending_refresh(
-    icm: InstanceConnectionManager,
+    instance: Instance,
     test_rate_limiter: AsyncRateLimiter,
 ) -> None:
     """
     Test that force_refresh cancels pending task if refresh_in_progress event is not set.
     """
     # allow more frequent refreshes for tests
-    setattr(icm, "_refresh_rate_limiter", test_rate_limiter)
+    setattr(instance, "_refresh_rate_limiter", test_rate_limiter)
 
     # since the pending refresh isn't for another 55 min, the refresh_in_progress event
     # shouldn't be set
-    pending_refresh = icm._next
+    pending_refresh = instance._next
 
-    assert icm._refresh_in_progress.is_set() is False
+    assert instance._refresh_in_progress.is_set() is False
 
-    icm.force_refresh()
+    instance.force_refresh()
 
     # pending_refresh has to be awaited for it to raised as cancelled
     with pytest.raises(asyncio.CancelledError):
@@ -230,60 +228,60 @@ async def test_force_refresh_cancels_pending_refresh(
 
     # verify pending_refresh has now been cancelled
     assert pending_refresh.cancelled() is True
-    assert isinstance(icm._current.result(), MockMetadata)
-    await icm.close()
+    assert isinstance(instance._current.result(), MockMetadata)
+    await instance.close()
 
 
 @pytest.mark.asyncio
 async def test_auth_init_with_credentials_object(
-    icm: InstanceConnectionManager, fake_credentials: Credentials
+    instance: Instance, fake_credentials: Credentials
 ) -> None:
     """
-    Test that InstanceConnectionManager's _auth_init initializes _credentials
+    Test that Instance's _auth_init initializes _credentials
     when passed a google.auth.credentials.Credentials object.
     """
-    setattr(icm, "_credentials", None)
+    setattr(instance, "_credentials", None)
     with patch(
-        "google.cloud.sql.connector.instance_connection_manager.with_scopes_if_required"
+        "google.cloud.sql.connector.instance.with_scopes_if_required"
     ) as mock_auth:
         mock_auth.return_value = fake_credentials
-        icm._auth_init(credentials=fake_credentials)
-        assert isinstance(icm._credentials, Credentials)
+        instance._auth_init(credentials=fake_credentials)
+        assert isinstance(instance._credentials, Credentials)
         mock_auth.assert_called_once()
-    await icm.close()
+    await instance.close()
 
 
 @pytest.mark.asyncio
 async def test_auth_init_with_default_credentials(
-    icm: InstanceConnectionManager, fake_credentials: Credentials
+    instance: Instance, fake_credentials: Credentials
 ) -> None:
     """
-    Test that InstanceConnectionManager's _auth_init initializes _credentials
+    Test that Instance's _auth_init initializes _credentials
     with application default credentials when credentials are not specified.
     """
-    setattr(icm, "_credentials", None)
+    setattr(instance, "_credentials", None)
     with patch("google.auth.default") as mock_auth:
         mock_auth.return_value = fake_credentials, None
-        icm._auth_init(credentials=None)
-        assert isinstance(icm._credentials, Credentials)
+        instance._auth_init(credentials=None)
+        assert isinstance(instance._credentials, Credentials)
         mock_auth.assert_called_once()
-    await icm.close()
+    await instance.close()
 
 
 @pytest.mark.asyncio
-async def test_InstanceConnectionManager_close(icm: InstanceConnectionManager) -> None:
+async def test_Instance_close(instance: Instance) -> None:
     """
-    Test that InstanceConnectionManager's close method
+    Test that Instance's close method
     cancels tasks and closes ClientSession.
     """
     # make sure current metadata task is done
-    await icm._current
-    assert icm._current.cancelled() is False
-    assert icm._next.cancelled() is False
-    assert icm._client_session.closed is False
+    await instance._current
+    assert instance._current.cancelled() is False
+    assert instance._next.cancelled() is False
+    assert instance._client_session.closed is False
     # run close() to cancel tasks and close ClientSession
-    await icm.close()
+    await instance.close()
     # verify tasks are cancelled and ClientSession is closed
-    assert (icm._current.done() or icm._current.cancelled()) is True
-    assert icm._next.cancelled() is True
-    assert icm._client_session.closed is True
+    assert (instance._current.done() or instance._current.cancelled()) is True
+    assert instance._next.cancelled() is True
+    assert instance._client_session.closed is True

--- a/tests/unit/test_refresh_utils.py
+++ b/tests/unit/test_refresh_utils.py
@@ -28,7 +28,7 @@ from google.cloud.sql.connector.refresh_utils import (
     _is_valid,
 )
 from google.cloud.sql.connector.utils import generate_keys
-from tests.unit.test_instance_connection_manager import (  # type: ignore
+from tests.unit.test_instance import (  # type: ignore
     _get_metadata_success,
     _get_metadata_expired,
 )


### PR DESCRIPTION
Renaming `InstanceConnectionManager` class to `Instance` as it no longer manages connections, that has been moved up a level to the connector.