### PR TITLE
feat!: deprecate default connect method

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ connector.close()
 
 **Note for SQL Server users**: If your SQL Server instance requires SSL, you need to download the CA certificate for your instance and include `cafile={path to downloaded certificate}` and `validate_host=False`. This is a workaround for a [known issue](https://issuetracker.google.com/184867147).
 
-### Custom Connector Object
+### Configuring the Connector
 
 If you need to customize something about the connector, or want to specify
 defaults for each connection to make, you can initialize a 

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -261,6 +261,13 @@ def connect(instance_connection_string: str, driver: str, **kwargs: Any) -> Any:
     :returns:
         A DB-API connection to the specified Cloud SQL instance.
     """
+    # deprecation warning
+    logger.warning(
+        "Default `connect` method is deprecated and will be removed in a later "
+        "version. Please initialize a `Connector` object and call it's `connect` "
+        "method directly. \n"
+        "See https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/blob/main/README.md#how-to-use-this-connector for examples.",
+    )
     global _default_connector
     if _default_connector is None:
         _default_connector = Connector()

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -263,7 +263,7 @@ def connect(instance_connection_string: str, driver: str, **kwargs: Any) -> Any:
     """
     # deprecation warning
     logger.warning(
-        "Default `connect` method is deprecated and will be removed in a later "
+        "The global `connect` method is deprecated and may be removed in a later "
         "version. Please initialize a `Connector` object and call it's `connect` "
         "method directly. \n"
         "See https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/blob/main/README.md#how-to-use-this-connector for examples.",


### PR DESCRIPTION
We want to now recommend to users to initialize a `Connector` object and not rely on the default `connect` method to do this for them. Will deprecate the default `connect` method in a future release. 