### PR TITLE
chore: allow renovate to configure all dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,6 @@
   "dependencyDashboard": true,
   "semanticCommits": true,
   "pip_requirements": {
-    "fileMatch": ["requirements-test.txt", "noxfile.py"]
+    "fileMatch": ["requirements-test.txt"]
   }
 }

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,17 +31,7 @@ def lint(session):
     Returns a failure if the linters find linting errors or sufficiently
     serious code quality issues.
     """
-    session.install(
-        "flake8==4.0.1",
-        "flake8-annotations==2.7.0",
-        "black==22.3.0",
-        "mypy==0.910",
-        "sqlalchemy-stubs==0.4",
-        "types-pkg-resources==0.1.3",
-        "types-PyMySQL==1.0.6",
-        "types-mock==4.0.5",
-        "twine==3.7.1",
-    )
+    session.install("-r", "requirements-test.txt")
     session.install("-r", "requirements.txt")
     session.run("black", "--check", *BLACK_PATHS)
     session.run("flake8", "google", "tests")

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,15 @@ pytest-cov==3.0.0
 pytest-asyncio==0.18.3
 SQLAlchemy==1.4.32
 sqlalchemy-pytds==0.3.4
+flake8==4.0.1
+flake8-annotations==2.7.0
+black==22.3.0
+mypy==0.910
+sqlalchemy-stubs==0.4
+types-pkg-resources==0.1.3
+types-PyMySQL==1.0.6
+types-mock==4.0.5
+twine==3.7.1
+PyMySQL==1.0.2
+pg8000==1.24.1
+python-tds==1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 aiohttp==3.8.1
 cryptography==36.0.2
-PyMySQL==1.0.2
-pg8000==1.24.1
-python-tds==1.11.0
 pyopenssl==22.0.0
 Requests==2.27.1
 google-auth==2.6.2


### PR DESCRIPTION
Updating dependencies to be reachable by renovate-bot as well as removing driver dependencies from basic requirements.txt