### PR TITLE
chore(deps): update mypy to 0.942

### DIFF
--- a/google/__init__.py
+++ b/google/__init__.py
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from typing import List
-
 try:
     import pkg_resources
 
@@ -21,4 +18,4 @@ try:
 except ImportError:
     import pkgutil
 
-    __path__: List[str] = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/google/cloud/__init__.py
+++ b/google/cloud/__init__.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List
-
 try:
     import pkg_resources
 
@@ -20,4 +18,4 @@ try:
 except ImportError:
     import pkgutil
 
-    __path__: List[str] = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/google/cloud/sql/connector/__init__.py
+++ b/google/cloud/sql/connector/__init__.py
@@ -13,9 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
-from typing import List
-
 from .connector import connect, Connector
 from .instance import IPTypes
 
@@ -29,4 +26,4 @@ try:
 except ImportError:
     import pkgutil
 
-    __path__: List[str] = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,7 @@ sqlalchemy-pytds==0.3.4
 flake8==4.0.1
 flake8-annotations==2.7.0
 black==22.3.0
-mypy==0.910
+mypy==0.942
 sqlalchemy-stubs==0.4
 types-pkg-resources==0.1.3
 types-PyMySQL==1.0.15


### PR DESCRIPTION
In `mypy==0.920` and beyond it is no longer required to type hint `__path__` as it defaults to the correct type.