### PR TITLE
chore: update core dependencies to use google-auth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ core_dependencies = [
     "cryptography",
     "pyopenssl",
     "Requests",
+    "google-auth",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ core_dependencies = [
     "cryptography",
     "pyopenssl",
     "Requests",
-    "google-api-python-client",
 ]
 
 setup(


### PR DESCRIPTION
Replace `google-api-python-client` with `google-auth` in core deps.