### PR TITLE
build: move unit tests to Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: tests
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: "unit tests"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        python-version: [3.7, 3.8, 3.9, 3.10]
+      fail-fast: false
+    steps:
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install nox
+        run: pip install nox
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run tests
+        run: nox -s unit-${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     steps:
       - name: Setup Python ${{ matrix.python-version }}

--- a/.kokoro/python3.10/linux/common.cfg
+++ b/.kokoro/python3.10/linux/common.cfg
@@ -37,5 +37,5 @@ env_vars: {
 # Specify which tests to run
 env_vars: {
     key: "RUN_TESTS_SESSION"
-    value: "test-3.10"
+    value: "system-3.10"
 }

--- a/.kokoro/python3.7/linux/common.cfg
+++ b/.kokoro/python3.7/linux/common.cfg
@@ -37,5 +37,5 @@ env_vars: {
 # Specify which tests to run
 env_vars: {
     key: "RUN_TESTS_SESSION"
-    value: "test-3.7"
+    value: "system-3.7"
 }

--- a/.kokoro/python3.7/windows/common.cfg
+++ b/.kokoro/python3.7/windows/common.cfg
@@ -24,5 +24,5 @@ build_file: "cloud-sql-python-connector/.kokoro/tests/run_tests.bat"
 # Specify which tests to run
 env_vars: {
     key: "RUN_TESTS_SESSION"
-    value: "test-3.7"
+    value: "system-3.7"
 }

--- a/.kokoro/python3.8/linux/common.cfg
+++ b/.kokoro/python3.8/linux/common.cfg
@@ -37,5 +37,5 @@ env_vars: {
 # Specify which tests to run
 env_vars: {
     key: "RUN_TESTS_SESSION"
-    value: "test-3.8"
+    value: "system-3.8"
 }

--- a/.kokoro/python3.9/linux/common.cfg
+++ b/.kokoro/python3.9/linux/common.cfg
@@ -37,5 +37,5 @@ env_vars: {
 # Specify which tests to run
 env_vars: {
     key: "RUN_TESTS_SESSION"
-    value: "test-3.9"
+    value: "system-3.9"
 }


### PR DESCRIPTION
Moving Python Connector unit tests from Kokoro to Github Actions. Additionally unit tests will now run on Mac builds.