### PR TITLE
feat!: remove deprecated global 'connector.connect' function

### DIFF
--- a/google/cloud/sql/connector/__init__.py
+++ b/google/cloud/sql/connector/__init__.py
@@ -13,11 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from .connector import connect, Connector
+from .connector import Connector
 from .instance import IPTypes
 
 
-__ALL__ = [connect, Connector, IPTypes]
+__ALL__ = [Connector, IPTypes]
 
 try:
     import pkg_resources

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -32,8 +32,6 @@ from functools import partial
 
 logger = logging.getLogger(name=__name__)
 
-_default_connector = None
-
 
 class Connector:
     """A class to configure and create connections to Cloud SQL instances.
@@ -236,41 +234,3 @@ class Connector:
         await asyncio.gather(
             *[instance.close() for instance in self._instances.values()]
         )
-
-
-def connect(instance_connection_string: str, driver: str, **kwargs: Any) -> Any:
-    """Uses a Connector object with default settings and returns a database
-    connection object with a background thread to refresh the certificates and metadata.
-    For more advanced configurations, callers should instantiate Connector on their own.
-
-    :type instance_connection_string: str
-    :param instance_connection_string:
-        A string containing the GCP project name, region name, and instance
-        name separated by colons.
-
-        Example: example-proj:example-region-us6:example-instance
-
-    :type driver: str
-    :param: driver:
-        A string representing the driver to connect with. Supported drivers are
-        pymysql, pg8000, and pytds.
-
-    :param kwargs:
-        Pass in any driver-specific arguments needed to connect to the Cloud
-        SQL instance.
-
-    :rtype: Connection
-    :returns:
-        A DB-API connection to the specified Cloud SQL instance.
-    """
-    # deprecation warning
-    logger.warning(
-        "The global `connect` method is deprecated and may be removed in a later "
-        "version. Please initialize a `Connector` object and call it's `connect` "
-        "method directly. \n"
-        "See https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/blob/main/README.md#how-to-use-this-connector for examples.",
-    )
-    global _default_connector
-    if _default_connector is None:
-        _default_connector = Connector()
-    return _default_connector.connect(instance_connection_string, driver, **kwargs)

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -18,8 +18,6 @@ import pytest  # noqa F401 Needed to run the tests
 import asyncio
 
 from google.cloud.sql.connector import Connector, IPTypes
-from google.cloud.sql.connector import connector as global_connector
-from google.cloud.sql.connector.connector import _default_connector
 
 from mock import patch
 from typing import Any
@@ -100,35 +98,3 @@ def test_Connector_connect(connector: Connector) -> None:
         )
         # verify connector made connection call
         assert connection is True
-
-
-def test_global_connect(connector: Connector) -> None:
-    """Test that global connect properly make connection call to default connector."""
-    connect_string = "my-project:my-region:my-instance"
-    # verify default_connector is not set
-    assert _default_connector is None
-    # set global connector
-    global_connector._default_connector = connector
-    # patch db connection creation
-    with patch("pg8000.dbapi.connect") as mock_connect:
-        mock_connect.return_value = True
-        # connect using global connector
-        connection = global_connector.connect(
-            connect_string, "pg8000", user="my-user", password="my-pass", db="my-db"
-        )
-
-    # verify default_connector is now set
-    from google.cloud.sql.connector.connector import (
-        _default_connector as default_connector,
-    )
-
-    assert isinstance(default_connector, Connector)
-
-    # verify attributes of default connector
-    assert default_connector._ip_type == IPTypes.PUBLIC
-    assert default_connector._enable_iam_auth is False
-    assert default_connector._timeout == 30
-    assert default_connector._credentials is None
-
-    # verify global connector made connection call
-    assert connection is True


### PR DESCRIPTION
The global `connector.connect(**kwargs)` has been deprecated for the past several months and should be replaced with a `Connector()` object initialization.

All instances of global `connector.connect` (bad):
```python
from google.cloud.sql.connector import connector

conn = connector.connect(
      ... arguments
)
```

Should be replaced with `Connector()` initialization (good):
```python
from google.cloud.sql.connector import Connector  # uppercase Connector

# initialize Connector object
with Connector() as connector:
  conn = connector.connect(
        ... arguments
  )
```
Refer to [README](https://github.com/GoogleCloudPlatform/cloud-sql-python-connector#how-to-use-this-connector) for more examples of using `Connector()`object.