### PR TITLE
chore(deps): update dependency pytest-asyncio to 0.19.0

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 pytest==7.1.2
 mock==4.0.3
 pytest-cov==3.0.0
-pytest-asyncio==0.18.3
+pytest-asyncio==0.19.0
 SQLAlchemy==1.4.39
 sqlalchemy-pytds==0.3.4
 flake8==4.0.1

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,15 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+[pytest]
+asyncio_mode = auto


### PR DESCRIPTION
Pytest now requires either `strict` or `auto` configuration to determine between pytest vs pytest-asyncio tests. 

Closes #401 