### PR TITLE
chore: enable release-trigger for one click releases

### DIFF
--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,0 +1,15 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+enabled: true


### PR DESCRIPTION
Enabling `release-trigger` on repo, should allow the merging of release-please PRs to kick off Kokoro release job, removing the manual step of the release process