### PR TITLE
fix: stop event loop on Connector.close

### DIFF
--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -284,8 +284,12 @@ class Connector:
         )
         # Will attempt to safely shut down tasks for 5s
         close_future.result(timeout=5)
-        # stop event loop (killing daemon thread)
-        self._loop.call_soon_threadsafe(self._loop.stop)
+        # if background thread exists for Connector, clean it up
+        if self._thread:
+            # stop event loop running in background thread
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            # wait for thread to finish closing (i.e. loop to stop)
+            self._thread.join()
 
     async def close_async(self) -> None:
         """Helper function to cancel Instances' tasks

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -284,6 +284,9 @@ class Connector:
         )
         # Will attempt to safely shut down tasks for 5s
         close_future.result(timeout=5)
+        # if background thread, stop event loop (killing daemon thread)
+        if self._thread:
+            self._loop.call_soon_threadsafe(self._loop.stop)
 
     async def close_async(self) -> None:
         """Helper function to cancel Instances' tasks

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -284,9 +284,8 @@ class Connector:
         )
         # Will attempt to safely shut down tasks for 5s
         close_future.result(timeout=5)
-        # if background thread, stop event loop (killing daemon thread)
-        if self._thread:
-            self._loop.call_soon_threadsafe(self._loop.stop)
+        # stop event loop (killing daemon thread)
+        self._loop.call_soon_threadsafe(self._loop.stop)
 
     async def close_async(self) -> None:
         """Helper function to cancel Instances' tasks

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 import pytest  # noqa F401 Needed to run the tests
 import asyncio
-import threading
 
 from google.cloud.sql.connector import Connector, IPTypes, create_async_connector
 from google.cloud.sql.connector.connector import ConnectorLoopError
@@ -159,14 +158,12 @@ async def test_create_async_connector() -> None:
     await connector.close_async()
 
 
-def test_Connector_close_kills_threads() -> None:
+def test_Connector_close_kills_thread() -> None:
     """Test that Connector.close kills background threads."""
-    # several fixtures use threads so get count prior to test
-    prior_threads = threading.active_count()
-    # open and close 10 Connector objects
-    for _ in range(10):
-        with Connector():
-            pass
-        # there can be a slight overlap when one Connector closes to
-        # when the next is created so difference is set to 2
-        assert threading.active_count() - prior_threads <= 2
+    # open and close Connector object
+    connector = Connector()
+    # verify background thread exists
+    assert connector._thread
+    connector.close()
+    # check that connector thread is no longer running
+    assert connector._thread.is_alive() is False

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -78,16 +78,15 @@ def test_connect_enable_iam_auth_error() -> None:
     connector._instances = {}
 
 
-def test_connect_with_unsupported_driver() -> None:
-    with Connector() as connector:
-        # try to connect using unsupported driver, should raise KeyError
-        with pytest.raises(KeyError) as exc_info:
-            connector.connect(
-                "my-project:my-region:my-instance",
-                "bad_driver",
-            )
-        # assert custom error message for unsupported driver is present
-        assert exc_info.value.args[0] == "Driver 'bad_driver' is not supported."
+def test_connect_with_unsupported_driver(connector: Connector) -> None:
+    # try to connect using unsupported driver, should raise KeyError
+    with pytest.raises(KeyError) as exc_info:
+        connector.connect(
+            "my-project:my-region:my-instance",
+            "bad_driver",
+        )
+    # assert custom error message for unsupported driver is present
+    assert exc_info.value.args[0] == "Driver 'bad_driver' is not supported."
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -78,16 +78,16 @@ def test_connect_enable_iam_auth_error() -> None:
     connector._instances = {}
 
 
-def test_connect_with_unsupported_driver(connector: Connector) -> None:
-    # try to connect using unsupported driver, should raise KeyError
-    with pytest.raises(KeyError) as exc_info:
-        connector.connect(
-            "my-project:my-region:my-instance",
-            "bad_driver",
-        )
-    # assert custom error message for unsupported driver is present
-    assert exc_info.value.args[0] == "Driver 'bad_driver' is not supported."
-    connector.close()
+def test_connect_with_unsupported_driver() -> None:
+    with Connector() as connector:
+        # try to connect using unsupported driver, should raise KeyError
+        with pytest.raises(KeyError) as exc_info:
+            connector.connect(
+                "my-project:my-region:my-instance",
+                "bad_driver",
+            )
+        # assert custom error message for unsupported driver is present
+        assert exc_info.value.args[0] == "Driver 'bad_driver' is not supported."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Background threads used for `Connector()` are daemon threads and by default do not get killed until process exits. Since we are spinning up these threads with `loop.run_forever` the thread will not get killed until the event loop is closed. Which in the current state is when the Python program exits, which is not efficient for long running programs.

To fix this, we should call `loop.stop` when closing a `Connector` object which will in turn kill the background daemon thread.

Closes #409 