### PR TITLE
Add pooled_connection option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,8 @@ export SQLSERVER_CONNECTION_NAME="your:connection:string"
 export SQLSERVER_USER="db_user"
 export SQLSERVER_PASS="db_pass"
 export SQLSERVER_DB="db_name"
+
+export GOOGLE_APPLICATION_CREDENTIALS="location/of/application_default_credentials.json"
 ```
 
 ### Running tests 

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -70,6 +70,11 @@ class Connector:
     :param loop
         Event loop to run asyncio tasks, if not specified, defaults to
         creating new event loop on background thread.
+
+    :type pooled_connection: bool
+    :param pooled_connection
+        Sets conservative values for certificate refresh, helpful when an
+        external pool manager is maintaining connection health.
     """
 
     def __init__(
@@ -79,6 +84,7 @@ class Connector:
         timeout: int = 30,
         credentials: Optional[Credentials] = None,
         loop: asyncio.AbstractEventLoop = None,
+        pooled_connection: bool = False,
     ) -> None:
         # if event loop is given, use for background tasks
         if loop:
@@ -101,6 +107,7 @@ class Connector:
         self._enable_iam_auth = enable_iam_auth
         self._ip_type = ip_type
         self._credentials = credentials
+        self._pooled_connection = pooled_connection
 
     def connect(
         self, instance_connection_string: str, driver: str, **kwargs: Any
@@ -195,6 +202,7 @@ class Connector:
                 self._loop,
                 self._credentials,
                 enable_iam_auth,
+                self._pooled_connection,
             )
             self._instances[instance_connection_string] = instance
 


### PR DESCRIPTION
feat: option for useful cert refresh behavior for pooled connections

When a pool of connections is being maintained by SQLAlchemy, there is no need for the connections to do their own maintenance, since SQLAlchemy already closes unhealthy connections and opens new connections as needed. And because pooled connections do not get closed actively, the current refresh behavior can result in too many connections being held open, and surges of refreshes every 55 minutes if multiple pools were opened at the same time. 

Similarly, the current behavior of immediately retrying a failed refresh can lead to a thundering herd of refreshes if the Cloud SQL API requests-per-minute quota has been exceeded. In a managed pool it will be safer to wait 60 seconds for the next quota period.

Separately, the connector is throwing asyncio errors (below), which are corrected by adding an explicit `close()` call to the `__client_session` after use. This action is moved to a separate method to avoid flake8 complexity complaints.

```
ERROR:asyncio:Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x10f1fd850>
ERROR:asyncio:Unclosed connector
```

Changes:
- Adds a `pooled_connection` option to `Connector` and `Instance` which modifies the behavior of certification refreshes. When true, timed refreshes are disabled. Also, failed refreshes are retried after 60 seconds.
- A new `_close_session` method is added to `Instance` to prevent unclosed `ClientSession` errors.
- Tests also require a `GOOGLE_APPLICATION_CREDENTIALS` envvar value, so that suggestion is added to `CONTRIBUTING.md`.

Testing: Passing tests continue to pass with these changes.