### PR TITLE
chore: drop pyopenssl core dependency

### DIFF
--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -32,8 +32,9 @@ import datetime
 from enum import Enum
 import google.auth
 from google.auth.credentials import Credentials, with_scopes_if_required
+from cryptography.x509 import load_pem_x509_certificate
+from cryptography.hazmat.backends import default_backend
 import google.auth.transport.requests
-import OpenSSL
 import ssl
 from tempfile import TemporaryDirectory
 from typing import (
@@ -343,12 +344,10 @@ class Instance:
                 metadata_task, ephemeral_task
             )
 
-            x509 = OpenSSL.crypto.load_certificate(
-                OpenSSL.crypto.FILETYPE_PEM, ephemeral_cert
+            x509 = load_pem_x509_certificate(
+                ephemeral_cert.encode("UTF-8"), default_backend()
             )
-            expiration = datetime.datetime.strptime(
-                x509.get_notAfter().decode("ascii"), "%Y%m%d%H%M%SZ"
-            )
+            expiration = x509.not_valid_after
 
             if self._enable_iam_auth:
                 if self._credentials is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aiohttp==3.8.1
 cryptography==37.0.4
-pyopenssl==22.0.0
 Requests==2.28.1
 google-auth==2.9.1

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ release_status = "Development Status :: 4 - Beta"
 core_dependencies = [
     "aiohttp",
     "cryptography",
-    "pyopenssl",
     "Requests",
     "google-auth",
 ]


### PR DESCRIPTION
The [`pyopenssl`](https://pypi.org/project/pyOpenSSL/) library recommends using the [`pyca/cryptography`](https://github.com/pyca/cryptography) library over its internal [crypto](https://www.pyopenssl.org/en/stable/api/crypto.html) module.

Note from the pyopenssl docs:

> Note: The Python Cryptographic Authority strongly suggests the use of [pyca/cryptography](https://github.com/pyca/cryptography) where possible. If you are using pyOpenSSL for anything other than making a TLS connection you should move to cryptography and drop your pyOpenSSL dependency.

We already have the `crypotgraphy` library as a core dependency, so we can consolidate usage to it and drop `pyopenssl`.
