### PR TITLE
chore: update dependency flake8-annotations to 2.9.1

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501, W503, ANN101
+ignore = E203, E266, E501, W503, ANN101, ANN401
 exclude =
   # Exclude generated code.
   **/proto/**

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,7 @@ pytest-asyncio==0.19.0
 SQLAlchemy==1.4.40
 sqlalchemy-pytds==0.3.4
 flake8==4.0.1
-flake8-annotations==2.7.0
+flake8-annotations==2.9.1
 black==22.6.0
 mypy==0.971
 sqlalchemy-stubs==0.4


### PR DESCRIPTION
In newer versions of `flake8-annotations` a new opinionated check `ANN401` was added that should be disabled by default to allow `typing.Any` type hints.

Closes #363 