### PR TITLE
chore: remove deprecated `ip_types` argument

### DIFF
--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -211,14 +211,7 @@ class Connector:
         except KeyError:
             raise KeyError(f"Driver '{driver}' is not supported.")
 
-        if "ip_types" in kwargs:
-            ip_type = kwargs.pop("ip_types")
-            logger.warning(
-                "Deprecation Warning: Parameter `ip_types` is deprecated and may be removed"
-                " in a future release. Please use `ip_type` instead."
-            )
-        else:
-            ip_type = kwargs.pop("ip_type", self._ip_type)
+        ip_type = kwargs.pop("ip_type", self._ip_type)
         timeout = kwargs.pop("timeout", self._timeout)
         if "connect_timeout" in kwargs:
             timeout = kwargs.pop("connect_timeout")


### PR DESCRIPTION
As part of #220 , we switched the connector argument `ip_types` to `ip_type` to better reflect the argument and meaning.

Removing the old `ip_types` option as it has been deprecated for several months now.