### PR TITLE
chore: link README image to blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <p align="center">
-    <img src="docs/images/cloud-sql-python-connector.png" alt="cloud-sql-python-connector image">
+    <a href="https://cloud.google.com/blog/topics/developers-practitioners/how-connect-cloud-sql-using-python-easy-way">
+        <img src="docs/images/cloud-sql-python-connector.png" alt="cloud-sql-python-connector image">
+    </a>
 </p>
 
 <h1 align="center">Cloud SQL Python Connector</h1>


### PR DESCRIPTION
Linking header image to [Python Connector blog](https://cloud.google.com/blog/topics/developers-practitioners/how-connect-cloud-sql-using-python-easy-way)

[Test it here](https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/tree/update-readme)