### PR TITLE
chore(ci): enable Flakybot on tests

### DIFF
--- a/.github/flakybot.yaml
+++ b/.github/flakybot.yaml
@@ -1,0 +1,15 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+issuePriority: p2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,7 +117,7 @@ jobs:
       
       - name: FlakyBot (Linux)
         # only run flakybot on periodic (schedule) and continuous (push) events
-        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
         run: |
           curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
           chmod +x ./flakybot
@@ -178,5 +178,34 @@ jobs:
       - name: Install nox
         run: pip install nox
 
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v0.8.1'
+        with:
+          workload_identity_provider: ${{ secrets.PROVIDER_NAME }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+          access_token_lifetime: 600s
+
       - name: Run tests
         run: nox -s unit-${{ matrix.python-version }}
+
+      - name: FlakyBot (Linux)
+        # only run flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
+        run: |
+          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
+          chmod +x ./flakybot
+          ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      - name: FlakyBot (Windows)
+        # only run flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
+        run: |
+          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot.exe -o flakybot.exe -s -L
+          ./flakybot.exe --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      - name: FlakyBot (macOS)
+        # only run flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'macOS' && always() }}
+        run: |
+          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot-darwin-amd64 -o flakybot -s -L
+          chmod +x ./flakybot
+          ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,7 +117,7 @@ jobs:
       
       - name: FlakyBot (Linux)
         # only run flakybot on periodic (schedule) and continuous (push) events
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
+        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
         run: |
           curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
           chmod +x ./flakybot

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,6 +146,9 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - name: Remove PR label
         if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,6 +114,27 @@ jobs:
           SQLSERVER_PASS: '${{ steps.secrets.outputs.SQLSERVER_PASS }}'
           SQLSERVER_DB: '${{ steps.secrets.outputs.SQLSERVER_DB }}'
         run: nox -s system-${{ matrix.python-version }}
+      
+      - name: FlakyBot (Linux)
+        # only run flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Linux' && always() }}
+        run: |
+          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot -o flakybot -s -L
+          chmod +x ./flakybot
+          ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      - name: FlakyBot (Windows)
+        # only run flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'Windows' && always() }}
+        run: |
+          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot.exe -o flakybot.exe -s -L
+          ./flakybot.exe --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+      - name: FlakyBot (macOS)
+        # only run flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && runner.os == 'macOS' && always() }}
+        run: |
+          curl https://github.com/googleapis/repo-automation-bots/releases/download/flakybot-1.1.0/flakybot-darwin-amd64 -o flakybot -s -L
+          chmod +x ./flakybot
+          ./flakybot --repo ${{github.repository}} --commit_hash ${{github.sha}} --build_url https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
   
   unit:
     # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)  

--- a/noxfile.py
+++ b/noxfile.py
@@ -53,7 +53,7 @@ def default(session, path):
         "--cov-config=.coveragerc",
         "--cov-report=",
         "--cov-fail-under=0",
-        "--junitxml=results.xml",
+        "--junitxml=sponge_log.xml",
         path,
         *session.posargs,
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -53,6 +53,7 @@ def default(session, path):
         "--cov-config=.coveragerc",
         "--cov-report=",
         "--cov-fail-under=0",
+        "--junitxml=results.xml",
         path,
         *session.posargs,
     )

--- a/tests/system/test_ip_types.py
+++ b/tests/system/test_ip_types.py
@@ -50,7 +50,6 @@ def test_public_ip() -> None:
         pool = init_connection_engine(connector, IPTypes.PUBLIC)
         with pool.connect() as conn:
             conn.execute("SELECT 1")
-        raise Exception
 
 
 @pytest.mark.private_ip

--- a/tests/system/test_ip_types.py
+++ b/tests/system/test_ip_types.py
@@ -50,6 +50,7 @@ def test_public_ip() -> None:
         pool = init_connection_engine(connector, IPTypes.PUBLIC)
         with pool.connect() as conn:
             conn.execute("SELECT 1")
+        raise Exception
 
 
 @pytest.mark.private_ip


### PR DESCRIPTION
Enabling Flakybot to create issues with `p2` label for tests that fail during `schedule` (periodic) or `push` (continuous) builds.

Example issue opened by FlakyBot: #448 