### PR TITLE
WIP: test pypy support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.9"]
       fail-fast: false
     permissions:
       contents: 'read'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.9"]
       fail-fast: false
     permissions:
       contents: 'read'

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,19 @@ def lint(session):
 
 
 def default(session, path):
-    print("Python Version: ", session.python)
+    # if pypy environment, skip unsupported tests and deps
+    if session.python == "pypy3.9":
+        # add pytest arg --pypy to skip tests
+        session.posargs.append("--pypy")
+        # remove asyncpg from requirements-test.txt
+        with open("requirements-test.txt", "r") as f:
+            lines = f.readlines()
+        with open("requirements-test.txt", "w") as f:
+            for line in lines:
+                if line.startswith("asyncpg"):
+                    pass
+                else:
+                    f.write(line)
     # Install all test dependencies, then install this package in-place.
     session.install("-r", "requirements-test.txt")
     session.install("-e", ".")
@@ -70,7 +82,7 @@ def system(session):
     default(session, os.path.join("tests", "system"))
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy3.9"])
 def test(session):
     default(session, os.path.join("tests", "unit"))
     default(session, os.path.join("tests", "system"))

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,6 +41,7 @@ def lint(session):
 
 
 def default(session, path):
+    print("Python Version: ", session.python)
     # Install all test dependencies, then install this package in-place.
     session.install("-r", "requirements-test.txt")
     session.install("-e", ".")

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,7 +64,7 @@ def unit(session):
     default(session, os.path.join("tests", "unit"))
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy3.9"])
 def system(session):
     default(session, os.path.join("tests", "system"))
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,7 @@ def default(session, path):
     )
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "pypy3.9"])
 def unit(session):
     default(session, os.path.join("tests", "unit"))
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,5 +15,6 @@ types-mock==4.0.15
 twine==4.0.1
 PyMySQL==1.0.2
 pg8000==1.29.1
+asyncpg==0.26.0
 python-tds==1.11.0
 aioresponses==0.7.3

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,6 +15,5 @@ types-mock==4.0.15
 twine==4.0.1
 PyMySQL==1.0.2
 pg8000==1.29.1
-asyncpg==0.26.0
 python-tds==1.11.0
 aioresponses==0.7.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,15 +60,15 @@ def pytest_configure(config: Any) -> None:
 
 def pytest_collection_modifyitems(config: Any, items: Any) -> None:
     # early exit, run all tests
-    if config.getoption("--run_private_ip") and config.getoption("--pypy") == False:
+    if config.getoption("--run_private_ip") and config.getoption("--pypy") is False:
         return
     skip_private_ip = pytest.mark.skip(reason="need --run_private_ip option to run")
     skip_pypy = pytest.mark.skip(reason="test is not supported for pypy")
-    if config.getoption("--run_private_ip") == False:
+    if config.getoption("--run_private_ip") is False:
         for item in items:
             if "private_ip" in item.keywords:
                 item.add_marker(skip_private_ip)
-    if config.getoption("--pypy") == True:
+    if config.getoption("--pypy"):
         for item in items:
             if "skip_pypy" in item.keywords:
                 item.add_marker(skip_pypy)

--- a/tests/system/test_asyncpg_connection.py
+++ b/tests/system/test_asyncpg_connection.py
@@ -29,7 +29,7 @@ table_name = f"books_{uuid.uuid4().hex}"
 async def setup() -> AsyncGenerator:
     # initialize Cloud SQL Python Connector object
     connector = await create_async_connector()
-    conn: asyncpg.Connection = await connector.connect_async(
+    conn = await connector.connect_async(
         os.environ["POSTGRES_CONNECTION_NAME"],
         "asyncpg",
         user=os.environ["POSTGRES_USER"],
@@ -51,7 +51,7 @@ async def setup() -> AsyncGenerator:
 
 @pytest.mark.skip(reason="skipping asyncpg tests to test pypy")
 @pytest.mark.asyncio
-async def test_connection_with_asyncpg(conn: asyncpg.Connection) -> None:
+async def test_connection_with_asyncpg(conn) -> None:
     await conn.execute(
         f"INSERT INTO {table_name} (id, title) VALUES ('book1', 'Book One')"
     )

--- a/tests/system/test_asyncpg_connection.py
+++ b/tests/system/test_asyncpg_connection.py
@@ -15,9 +15,10 @@ limitations under the License.
 """
 import os
 import uuid
-from typing import AsyncGenerator
+from typing import AsyncGenerator, TYPE_CHECKING
 
-import asyncpg
+if TYPE_CHECKING:
+    import asyncpg
 import pytest
 from google.cloud.sql.connector import create_async_connector
 
@@ -48,7 +49,7 @@ async def setup() -> AsyncGenerator:
     # cleanup Connector object
     await connector.close_async()
 
-
+@pytest.mark.skip(reason="skipping asyncpg tests to test pypy")
 @pytest.mark.asyncio
 async def test_connection_with_asyncpg(conn: asyncpg.Connection) -> None:
     await conn.execute(

--- a/tests/system/test_asyncpg_connection.py
+++ b/tests/system/test_asyncpg_connection.py
@@ -49,9 +49,10 @@ async def setup() -> AsyncGenerator:
     # cleanup Connector object
     await connector.close_async()
 
-@pytest.mark.skip(reason="skipping asyncpg tests to test pypy")
+
+@pytest.mark.skip_pypy
 @pytest.mark.asyncio
-async def test_connection_with_asyncpg(conn) -> None:
+async def test_connection_with_asyncpg(conn: "asyncpg.Connection") -> None:
     await conn.execute(
         f"INSERT INTO {table_name} (id, title) VALUES ('book1', 'Book One')"
     )

--- a/tests/system/test_asyncpg_iam_auth.py
+++ b/tests/system/test_asyncpg_iam_auth.py
@@ -29,7 +29,7 @@ table_name = f"books_{uuid.uuid4().hex}"
 async def setup() -> AsyncGenerator:
     # initialize Cloud SQL Python Connector object
     connector = await create_async_connector()
-    conn: asyncpg.Connection = await connector.connect_async(
+    conn = await connector.connect_async(
         os.environ["POSTGRES_IAM_CONNECTION_NAME"],
         "asyncpg",
         user=os.environ["POSTGRES_IAM_USER"],
@@ -51,7 +51,7 @@ async def setup() -> AsyncGenerator:
 
 @pytest.mark.skip(reason="skipping asyncpg tests to test pypy")
 @pytest.mark.asyncio
-async def test_connection_with_asyncpg_iam_auth(conn: asyncpg.Connection) -> None:
+async def test_connection_with_asyncpg_iam_auth(conn) -> None:
     await conn.execute(
         f"INSERT INTO {table_name} (id, title) VALUES ('book1', 'Book One')"
     )

--- a/tests/system/test_asyncpg_iam_auth.py
+++ b/tests/system/test_asyncpg_iam_auth.py
@@ -15,9 +15,10 @@ limitations under the License.
 """
 import os
 import uuid
-from typing import AsyncGenerator
+from typing import AsyncGenerator, TYPE_CHECKING
 
-import asyncpg
+if TYPE_CHECKING:
+    import asyncpg
 import pytest
 from google.cloud.sql.connector import create_async_connector
 
@@ -48,7 +49,7 @@ async def setup() -> AsyncGenerator:
     # cleanup Connector object
     await connector.close_async()
 
-
+@pytest.mark.skip(reason="skipping asyncpg tests to test pypy")
 @pytest.mark.asyncio
 async def test_connection_with_asyncpg_iam_auth(conn: asyncpg.Connection) -> None:
     await conn.execute(

--- a/tests/system/test_asyncpg_iam_auth.py
+++ b/tests/system/test_asyncpg_iam_auth.py
@@ -49,9 +49,10 @@ async def setup() -> AsyncGenerator:
     # cleanup Connector object
     await connector.close_async()
 
-@pytest.mark.skip(reason="skipping asyncpg tests to test pypy")
+
+@pytest.mark.skip_pypy
 @pytest.mark.asyncio
-async def test_connection_with_asyncpg_iam_auth(conn) -> None:
+async def test_connection_with_asyncpg_iam_auth(conn: "asyncpg.Connection") -> None:
     await conn.execute(
         f"INSERT INTO {table_name} (id, title) VALUES ('book1', 'Book One')"
     )

--- a/tests/unit/test_asyncpg.py
+++ b/tests/unit/test_asyncpg.py
@@ -20,7 +20,8 @@ from mock import patch, AsyncMock
 
 from google.cloud.sql.connector.asyncpg import connect
 
-@pytest.mark.skip(reason="skipping asyncpg tests to test pypy")
+
+@pytest.mark.skip_pypy
 @pytest.mark.asyncio
 @patch("asyncpg.connect", new_callable=AsyncMock)
 async def test_asyncpg(mock_connect: AsyncMock, kwargs: Any) -> None:

--- a/tests/unit/test_asyncpg.py
+++ b/tests/unit/test_asyncpg.py
@@ -20,7 +20,7 @@ from mock import patch, AsyncMock
 
 from google.cloud.sql.connector.asyncpg import connect
 
-
+@pytest.mark.skip(reason="skipping asyncpg tests to test pypy")
 @pytest.mark.asyncio
 @patch("asyncpg.connect", new_callable=AsyncMock)
 async def test_asyncpg(mock_connect: AsyncMock, kwargs: Any) -> None:


### PR DESCRIPTION
Testing [pypy](https://www.pypy.org/) with the Python Connector

- [asyncpg](https://github.com/MagicStack/asyncpg/issues/675) does not support `pypy` since it is a hardcore C-API extension
- Python connector usage with `pymysql`, `pg8000`, `pytds` drivers is supported with `pypy`