### PR TITLE
chore: update py.test to pytest

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -47,7 +47,7 @@ def default(session, path):
     session.install("-r", "requirements.txt")
     # Run py.test against the unit tests.
     session.run(
-        "py.test",
+        "pytest",
         "--cov=google/cloud/sql/connector",
         "-v",
         "--cov-config=.coveragerc",


### PR DESCRIPTION
`py.test` is the old invocation of pytests. The newer version is `pytest` and `py.test` will most likely be [deprecated in the future](https://stackoverflow.com/questions/39495429/py-test-vs-pytest-command). 