### PR TITLE
chore: remove re-raised exceptions from stacktrace

### DIFF
--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -409,11 +409,11 @@ class Instance:
                 e.message = "Forbidden: Authenticated IAM principal does not seeem authorized to make API request. Verify 'Cloud SQL Admin API' is enabled within your GCP project and 'Cloud SQL Client' role has been granted to IAM principal."
             raise
 
-        except Exception as e:
+        except Exception:
             logger.debug(
                 f"['{self._instance_connection_string}']: Error occurred during _perform_refresh."
             )
-            raise e
+            raise
 
         finally:
             self._refresh_in_progress.clear()
@@ -451,11 +451,11 @@ class Instance:
                     await asyncio.sleep(delay)
                 refresh_task = self._loop.create_task(self._perform_refresh())
                 refresh_data = await refresh_task
-            except asyncio.CancelledError as e:
+            except asyncio.CancelledError:
                 logger.debug(
                     f"['{self._instance_connection_string}']: Schedule refresh task cancelled."
                 )
-                raise e
+                raise
             # bad refresh attempt
             except Exception as e:
                 logger.exception(
@@ -470,7 +470,7 @@ class Instance:
                     self._current = refresh_task
                 # schedule new refresh attempt immediately
                 self._next = self._schedule_refresh(0)
-                raise e
+                raise
             # if valid refresh, replace current with valid metadata and schedule next refresh
             self._current = refresh_task
             # Ephemeral certificate expires in 1 hour, so we schedule a refresh to happen in 55 minutes.


### PR DESCRIPTION
Re-raising an error through `raise e` adds the re-raise to the stracktrace while just using `raise` will preserve the stacktrace as is.

`raise e` stacktrace:
```
 File "/usr/local/google/home/jackwoth/.pyenv/versions/3.10.1/lib/python3.10/site-packages/google/cloud/sql/connector/refresh_utils.py", line 224, in _is_valid
    metadata = await task
  File "/usr/local/google/home/jackwoth/.pyenv/versions/3.10.1/lib/python3.10/site-packages/google/cloud/sql/connector/connector.py", line 245, in get_connection
    instance_data, ip_address = await instance.connect_info(ip_type)
  File "/usr/local/google/home/jackwoth/.pyenv/versions/3.10.1/lib/python3.10/site-packages/google/cloud/sql/connector/instance.py", line 512, in connect_info
    instance_data = await self._current
  File "/usr/local/google/home/jackwoth/.pyenv/versions/3.10.1/lib/python3.10/site-packages/google/cloud/sql/connector/instance.py", line 473, in _refresh_task
    raise e
  File "/usr/local/google/home/jackwoth/.pyenv/versions/3.10.1/lib/python3.10/site-packages/google/cloud/sql/connector/instance.py", line 453, in _refresh_task
    refresh_data = await refresh_task
  File "/usr/local/google/home/jackwoth/.pyenv/versions/3.10.1/lib/python3.10/site-packages/google/cloud/sql/connector/instance.py", line 416, in _perform_refresh
    raise e
  File "/usr/local/google/home/jackwoth/.pyenv/versions/3.10.1/lib/python3.10/site-packages/google/cloud/sql/connector/instance.py", line 353, in _perform_refresh
    raise Exception("BOOM, raising exception!")
Exception: BOOM, raising exception!
```

`raise` stacktrace:
```
File "/usr/local/google/home/jackwoth/.pyenv/versions/3.10.1/lib/python3.10/site-packages/google/cloud/sql/connector/refresh_utils.py", line 224, in _is_valid
    metadata = await task
  File "/usr/local/google/home/jackwoth/.pyenv/versions/3.10.1/lib/python3.10/site-packages/google/cloud/sql/connector/connector.py", line 245, in get_connection
    instance_data, ip_address = await instance.connect_info(ip_type)
  File "/usr/local/google/home/jackwoth/.pyenv/versions/3.10.1/lib/python3.10/site-packages/google/cloud/sql/connector/instance.py", line 512, in connect_info
    instance_data = await self._current
  File "/usr/local/google/home/jackwoth/.pyenv/versions/3.10.1/lib/python3.10/site-packages/google/cloud/sql/connector/instance.py", line 453, in _refresh_task
    refresh_data = await refresh_task
  File "/usr/local/google/home/jackwoth/.pyenv/versions/3.10.1/lib/python3.10/site-packages/google/cloud/sql/connector/instance.py", line 353, in _perform_refresh
    raise Exception("BOOM, raising exception!")
Exception: BOOM, raising exception!
```