### PR TITLE
chore: move custom exceptions to exceptions.py

### DIFF
--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -25,6 +25,7 @@ import google.cloud.sql.connector.pg8000 as pg8000
 import google.cloud.sql.connector.pytds as pytds
 import google.cloud.sql.connector.asyncpg as asyncpg
 from google.cloud.sql.connector.utils import generate_keys
+from google.cloud.sql.connector.exceptions import ConnectorLoopError
 from google.auth.credentials import Credentials
 from threading import Thread
 from typing import Any, Dict, Optional, Type
@@ -33,16 +34,6 @@ from functools import partial
 logger = logging.getLogger(name=__name__)
 
 ASYNC_DRIVERS = ["asyncpg"]
-
-
-class ConnectorLoopError(Exception):
-    """
-    Raised when Connector.connect is called with Connector._loop
-        in an invalid state (event loop in current thread).
-    """
-
-    def __init__(self, *args: Any) -> None:
-        super(ConnectorLoopError, self).__init__(self, *args)
 
 
 class Connector:

--- a/google/cloud/sql/connector/exceptions.py
+++ b/google/cloud/sql/connector/exceptions.py
@@ -1,0 +1,65 @@
+"""
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+class ConnectorLoopError(Exception):
+    """
+    Raised when Connector.connect is called with Connector._loop
+    in an invalid state (event loop in current thread).
+    """
+
+    pass
+
+
+class TLSVersionError(Exception):
+    """
+    Raised when the required TLS protocol version is not supported.
+    """
+
+    pass
+
+
+class CloudSQLIPTypeError(Exception):
+    """
+    Raised when IP address for the preferred IP type is not found.
+    """
+
+    pass
+
+
+class PlatformNotSupportedError(Exception):
+    """
+    Raised when a feature is not supported on the current platform.
+    """
+
+    pass
+
+
+class CredentialsTypeError(Exception):
+    """
+    Raised when credentials parameter is not proper type.
+    """
+
+    pass
+
+
+class AutoIAMAuthNotSupported(Exception):
+    """
+    Exception to be raised when Automatic IAM Authentication is not
+    supported with database engine version.f
+    """
+
+    pass

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -24,6 +24,12 @@ from google.cloud.sql.connector.refresh_utils import (
 )
 from google.cloud.sql.connector.utils import write_to_file
 from google.cloud.sql.connector.version import __version__ as version
+from google.cloud.sql.connector.exceptions import (
+    TLSVersionError,
+    CloudSQLIPTypeError,
+    CredentialsTypeError,
+    AutoIAMAuthNotSupported,
+)
 
 # Importing libraries
 import asyncio
@@ -53,60 +59,6 @@ APPLICATION_NAME = "cloud-sql-python-connector"
 class IPTypes(Enum):
     PUBLIC: str = "PRIMARY"
     PRIVATE: str = "PRIVATE"
-
-
-class TLSVersionError(Exception):
-    """
-    Raised when the required TLS protocol version is not supported.
-    """
-
-    def __init__(self, *args: Any) -> None:
-        super(TLSVersionError, self).__init__(self, *args)
-
-
-class CloudSQLIPTypeError(Exception):
-    """
-    Raised when IP address for the preferred IP type is not found.
-    """
-
-    def __init__(self, *args: Any) -> None:
-        super(CloudSQLIPTypeError, self).__init__(self, *args)
-
-
-class PlatformNotSupportedError(Exception):
-    """
-    Raised when a feature is not supported on the current platform.
-    """
-
-    def __init__(self, *args: Any) -> None:
-        super(PlatformNotSupportedError, self).__init__(self, *args)
-
-
-class CredentialsTypeError(Exception):
-    """
-    Raised when credentials parameter is not proper type.
-    """
-
-    def __init__(self, *args: Any) -> None:
-        super(CredentialsTypeError, self).__init__(self, *args)
-
-
-class ExpiredInstanceMetadata(Exception):
-    """
-    Raised when InstanceMetadata is expired.
-    """
-
-    def __init__(self, *args: Any) -> None:
-        super(ExpiredInstanceMetadata, self).__init__(self, *args)
-
-
-class AutoIAMAuthNotSupported(Exception):
-    """
-    Exception to be raised when Automatic IAM Authentication is not
-    supported with database engine version.
-    """
-
-    pass
 
 
 class InstanceMetadata:

--- a/google/cloud/sql/connector/pytds.py
+++ b/google/cloud/sql/connector/pytds.py
@@ -17,9 +17,7 @@ import ssl
 import socket
 import platform
 from typing import Any, TYPE_CHECKING
-from google.cloud.sql.connector.instance import (
-    PlatformNotSupportedError,
-)
+from google.cloud.sql.connector.exceptions import PlatformNotSupportedError
 
 SERVER_PROXY_PORT = 3307
 

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -18,7 +18,7 @@ import pytest  # noqa F401 Needed to run the tests
 import asyncio
 
 from google.cloud.sql.connector import Connector, IPTypes, create_async_connector
-from google.cloud.sql.connector.connector import ConnectorLoopError
+from google.cloud.sql.connector.exceptions import ConnectorLoopError
 
 from mock import patch
 from typing import Any

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -20,12 +20,14 @@ import datetime
 from google.cloud.sql.connector.rate_limiter import AsyncRateLimiter
 from google.auth.credentials import Credentials
 from google.cloud.sql.connector.instance import (
-    AutoIAMAuthNotSupported,
     IPTypes,
     Instance,
-    CredentialsTypeError,
-    CloudSQLIPTypeError,
     InstanceMetadata,
+)
+from google.cloud.sql.connector.exceptions import (
+    AutoIAMAuthNotSupported,
+    CloudSQLIPTypeError,
+    CredentialsTypeError,
 )
 from google.cloud.sql.connector.utils import generate_keys
 from mock import patch

--- a/tests/unit/test_pytds.py
+++ b/tests/unit/test_pytds.py
@@ -17,7 +17,7 @@ import pytest
 from unittest.mock import patch
 import platform
 from typing import Any
-from google.cloud.sql.connector.instance import PlatformNotSupportedError
+from google.cloud.sql.connector.exceptions import PlatformNotSupportedError
 from mocks import create_ssl_context
 from google.cloud.sql.connector.pytds import connect
 from functools import partial


### PR DESCRIPTION
Moving all custom exceptions to `exceptions.py` to keep main files focused on application code.