### PR TITLE
feat: downscope token used for IAM DB AuthN

### DIFF
--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -261,10 +261,7 @@ class Instance:
             Credentials object used to authenticate connections to Cloud SQL server.
             If not specified, Application Default Credentials are used.
         """
-        scopes = [
-            "https://www.googleapis.com/auth/sqlservice.admin",
-            "https://www.googleapis.com/auth/cloud-platform",
-        ]
+        scopes = ["https://www.googleapis.com/auth/sqlservice.admin"]
         # if Credentials object is passed in, use for authentication
         if isinstance(credentials, Credentials):
             credentials = with_scopes_if_required(credentials, scopes=scopes)

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -167,7 +167,7 @@ async def _get_ephemeral(
     elif not isinstance(pub_key, str):
         raise TypeError(f"pub_key must be of type str, got {type(pub_key)}")
 
-    if not credentials.valid or enable_iam_auth:
+    if not credentials.valid:
         request = google.auth.transport.requests.Request()
         credentials.refresh(request)
 
@@ -258,6 +258,8 @@ def _downscope_credentials(
     else:
         # create shallow copy to not overwrite scopes on default credentials
         scoped_creds = copy.copy(credentials)
+        # overwrite '_scopes' to down-scope user credentials
+        # Cloud SDK reference: https://github.com/google-cloud-sdk-unofficial/google-cloud-sdk/blob/93920ccb6d2cce0fe6d1ce841e9e33410551d66b/lib/googlecloudsdk/command_lib/sql/generate_login_token_util.py#L116
         scoped_creds._scopes = scopes
     # down-scoped credentials require refresh, are invalid after being re-scoped
     if not scoped_creds.valid:

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -237,6 +237,19 @@ def _downscope_credentials(
     credentials: Credentials,
     scopes: List[str] = ["https://www.googleapis.com/auth/sqlservice.login"],
 ) -> Credentials:
+    """Generate a down-scoped credential.
+
+    :type credentials: google.auth.credentials.Credentials
+    :param credentials
+        Credentials object used to generate down-scoped credentials.
+
+    :type scopes: List[str]
+    :param scopes
+        List of Google scopes to include in down-scoped credentials object.
+
+    :rtype: google.auth.credentials.Credentials
+    :returns: Down-scoped credentials object.
+    """
     if isinstance(credentials, Scoped):
         scoped_creds = credentials.with_scopes(scopes=scopes)
     # authenticated user credentials can not be re-scoped

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -182,6 +182,7 @@ async def _get_ephemeral(
     data = {"public_key": pub_key}
 
     if enable_iam_auth:
+        # down-scope credentials with only IAM login scope (refreshes them too)
         login_creds = _downscope_credentials(credentials)
         data["access_token"] = login_creds.token
 

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -250,6 +250,8 @@ def _downscope_credentials(
     :rtype: google.auth.credentials.Credentials
     :returns: Down-scoped credentials object.
     """
+    # credentials sourced from a service account or metadata are children of
+    # Scoped class and are capable of being re-scoped
     if isinstance(credentials, Scoped):
         scoped_creds = credentials.with_scopes(scopes=scopes)
     # authenticated user credentials can not be re-scoped
@@ -257,7 +259,7 @@ def _downscope_credentials(
         # create shallow copy to not overwrite scopes on default credentials
         scoped_creds = copy.copy(credentials)
         scoped_creds._scopes = scopes
-    # downscoped credentials require refresh
+    # down-scoped credentials require refresh, are invalid after being re-scoped
     if not scoped_creds.valid:
         request = google.auth.transport.requests.Request()
         scoped_creds.refresh(request)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,10 +30,7 @@ from google.cloud.sql.connector import Connector
 from google.cloud.sql.connector.instance import Instance
 from google.cloud.sql.connector.utils import generate_keys
 
-SCOPES = [
-    "https://www.googleapis.com/auth/sqlservice.admin",
-    "https://www.googleapis.com/auth/cloud-platform",
-]
+SCOPES = ["https://www.googleapis.com/auth/sqlservice.admin"]
 
 
 def pytest_addoption(parser: Any) -> None:

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -294,7 +294,9 @@ async def test_perform_refresh_expiration(
     expiration = datetime.datetime.utcnow() + datetime.timedelta(minutes=1)
     setattr(instance._credentials, "expiry", expiration)
     setattr(instance, "_enable_iam_auth", True)
-    instance_metadata = await instance._perform_refresh()
+    # set all credentials to valid so downscoped credential does not refresh
+    with patch.object(Credentials, "valid", True):
+        instance_metadata = await instance._perform_refresh()
 
     # verify instance metadata object is returned
     assert isinstance(instance_metadata, InstanceMetadata)

--- a/tests/unit/test_refresh_utils.py
+++ b/tests/unit/test_refresh_utils.py
@@ -237,6 +237,10 @@ async def test_is_valid_with_expired_metadata() -> None:
 
 
 def test_downscope_credentials_service_account(fake_credentials: Credentials) -> None:
+    """
+    Test _downscope_credentials with google.oauth2.service_account.Credentials
+    which mimics an authenticated service account.
+    """
     # set all credentials to valid to skip refreshing credentials
     with patch.object(Credentials, "valid", True):
         credentials = _downscope_credentials(fake_credentials)
@@ -248,6 +252,10 @@ def test_downscope_credentials_service_account(fake_credentials: Credentials) ->
 
 
 def test_downscope_credentials_user() -> None:
+    """
+    Test _downscope_credentials with google.oauth2.credentials.Credentials
+    which mimics an authenticated user.
+    """
     creds = google.oauth2.credentials.Credentials("token", scopes=SCOPES)
     # set all credentials to valid to skip refreshing credentials
     with patch.object(Credentials, "valid", True):

--- a/tests/unit/test_refresh_utils.py
+++ b/tests/unit/test_refresh_utils.py
@@ -17,8 +17,9 @@ from typing import Any, no_type_check
 
 import aiohttp
 from google.auth.credentials import Credentials
+import google.oauth2.credentials
 import pytest  # noqa F401 Needed to run the tests
-from mock import Mock
+from mock import Mock, patch
 from aioresponses import aioresponses
 import asyncio
 
@@ -26,6 +27,7 @@ from google.cloud.sql.connector.refresh_utils import (
     _get_ephemeral,
     _get_metadata,
     _is_valid,
+    _downscope_credentials,
 )
 from google.cloud.sql.connector.utils import generate_keys
 
@@ -35,6 +37,7 @@ from mocks import (  # type: ignore
     instance_metadata_expired,
     FakeCSQLInstance,
 )
+from tests.conftest import SCOPES  # type: ignore
 
 
 @pytest.fixture
@@ -231,3 +234,26 @@ async def test_is_valid_with_expired_metadata() -> None:
     # task that returns class with expiration 10 mins in past
     task = asyncio.create_task(instance_metadata_expired())
     assert not await _is_valid(task)
+
+
+def test_downscope_credentials_service_account(fake_credentials: Credentials) -> None:
+    # set all credentials to valid to skip refreshing credentials
+    with patch.object(Credentials, "valid", True):
+        credentials = _downscope_credentials(fake_credentials)
+    # verify default credential scopes have not been altered
+    assert fake_credentials.scopes == SCOPES
+    # verify downscoped credentials have new scope
+    assert credentials.scopes == ["https://www.googleapis.com/auth/sqlservice.login"]
+    assert credentials != fake_credentials
+
+
+def test_downscope_credentials_user() -> None:
+    creds = google.oauth2.credentials.Credentials("token", scopes=SCOPES)
+    # set all credentials to valid to skip refreshing credentials
+    with patch.object(Credentials, "valid", True):
+        credentials = _downscope_credentials(creds)
+    # verify default credential scopes have not been altered
+    assert creds.scopes == SCOPES
+    # verify downscoped credentials have new scope
+    assert credentials.scopes == ["https://www.googleapis.com/auth/sqlservice.login"]
+    assert credentials != creds


### PR DESCRIPTION
Down-scope credentials and OAuth2 token used in `generateEphemeral` API request for IAM AuthN to have only `"https://www.googleapis.com/auth/sqlservice.login"` scope.

Closes #486 