### PR TITLE
fix: set minimum version constraint on cryptography

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ version = version["__version__"]
 release_status = "Development Status :: 4 - Beta"
 core_dependencies = [
     "aiohttp",
-    "cryptography",
+    "cryptography>=38.0.3",
     "Requests",
     "google-auth",
 ]


### PR DESCRIPTION
Adding constraint on [`cryptography`](https://cryptography.io/en/latest/) dependency due to vulnerability found in OpenSSL.

Cryptography 38.0.3 release notes: 
> Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.0.7, which resolves CVE-2022-3602 and CVE-2022-3786.