### PR TITLE
fix: update TLS protocol for python3.10

### DIFF
--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -79,7 +79,11 @@ class InstanceMetadata:
     ) -> None:
         self.ip_addrs = ip_addrs
         self.database_version = database_version
-        self.context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        self.context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+        # update ssl.PROTOCOL_TLS_CLIENT defaults
+        self.context.check_hostname = False
+        self.context.verify_mode = ssl.VerifyMode.CERT_NONE
 
         # verify OpenSSL version supports TLSv1.3
         if ssl.HAS_TLSv1_3:

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -81,9 +81,8 @@ class InstanceMetadata:
         self.database_version = database_version
         self.context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
-        # update ssl.PROTOCOL_TLS_CLIENT defaults
+        # update ssl.PROTOCOL_TLS_CLIENT default
         self.context.check_hostname = False
-        self.context.verify_mode = ssl.VerifyMode.CERT_NONE
 
         # verify OpenSSL version supports TLSv1.3
         if ssl.HAS_TLSv1_3:


### PR DESCRIPTION
In Python 3.10, `ssl.PROTOCOL_TLS` is deprecated and outputs warnings in logs/tests:
```
DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
  self.context = ssl.SSLContext(ssl.PROTOCOL_TLS)
```
 Instead, one of [`ssl.PROTOCOL_TLS_CLIENT`](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT) or [`ssl.PROTOCOL_TLS_SERVER`](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_SERVER) should be used, in our case CLIENT.

However, `ssl.PROTOCOL_TLS_CLIENT` brings with it some [new changes](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT). It sets `check_hostname` to True and `verify_mode` to `CERT_REQUIRED` by default. (`PROTOCOL_TLS` defaulted these values to False and CERT_NONE)

These new defaults lead to an error when using the TLS connection:
```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: IP address mismatch, certificate is not valid for 'XXX.XXX.XX.XX'.
```

Because of this I have added changing the defaults into the current PR.