### PR TITLE
chore: consolidate string formatting to f-strings

### DIFF
--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -91,12 +91,10 @@ async def _get_metadata(
         credentials.refresh(request)
 
     headers = {
-        "Authorization": "Bearer {}".format(credentials.token),
+        "Authorization": f"Bearer {credentials.token}",
     }
 
-    url = "{}/sql/{}/projects/{}/instances/{}/connectSettings".format(
-        sqladmin_api_endpoint, _sql_api_version, project, instance
-    )
+    url = f"{sqladmin_api_endpoint}/sql/{_sql_api_version}/projects/{project}/instances/{instance}/connectSettings"
 
     logger.debug(f"['{instance}']: Requesting metadata")
 
@@ -176,9 +174,7 @@ async def _get_ephemeral(
         "Authorization": f"Bearer {credentials.token}",
     }
 
-    url = "{}/sql/{}/projects/{}/instances/{}:generateEphemeralCert".format(
-        sqladmin_api_endpoint, _sql_api_version, project, instance
-    )
+    url = f"{sqladmin_api_endpoint}/sql/{_sql_api_version}/projects/{project}/instances/{instance}:generateEphemeralCert"
 
     data = {"public_key": pub_key}
 

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -91,7 +91,7 @@ def generate_cert(
             x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "California"),
             x509.NameAttribute(NameOID.LOCALITY_NAME, "Mountain View"),
             x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Google Inc"),
-            x509.NameAttribute(NameOID.COMMON_NAME, "{}".format(common_name)),
+            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
         ]
     )
     # build cert


### PR DESCRIPTION
Consolidating string formatting to f-strings as they are more efficient than `.format()`