### PR TITLE
chore: update trusted-contribution.yml

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -15,3 +15,5 @@
 annotations:
   - type: label
     text: "tests: run"
+
+trustedContributors: ['renovate-bot', 'gcf-merge-on-green[bot]']


### PR DESCRIPTION
Removing `release-please[bot]` from trusted contributors as we now use the Release Please app on this repo and it uses internal branches for PRs, no longer requiring the `tests: run` label to be added to release PRs.