### PR TITLE
chore(deps): update sqlalchemy to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ with pool.connect() as db_conn:
     db_conn.execute(insert_stmt, id="book1", title="Book One")
 
     # query database
-    result = db_conn.execute("SELECT * from my_table").fetchall()
+    result = db_conn.execute(sqlalchemy.text("SELECT * from my_table")).fetchall()
 
     # Do something with the results
     for row in result:
@@ -186,6 +186,7 @@ Connector as a context manager:
 
 ```python
 from google.cloud.sql.connector import Connector
+import sqlalchemy
 
 # build connection
 def getconn() -> pymysql.connections.Connection:
@@ -216,7 +217,7 @@ with pool.connect() as db_conn:
     db_conn.execute(insert_stmt, id="book1", title="Book One")
 
     # query database
-    result = db_conn.execute("SELECT * from my_table").fetchall()
+    result = db_conn.execute(sqlalchemy.text("SELECT * from my_table")).fetchall()
 
     # Do something with the results
     for row in result:

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ insert_stmt = sqlalchemy.text(
 
 with pool.connect() as db_conn:
     # insert into database
-    db_conn.execute(insert_stmt, id="book1", title="Book One")
+    db_conn.execute(insert_stmt, parameters={"id": "book1", "title": "Book One"})
 
     # query database
     result = db_conn.execute(sqlalchemy.text("SELECT * from my_table")).fetchall()
@@ -214,7 +214,7 @@ insert_stmt = sqlalchemy.text(
 # interact with Cloud SQL database using connection pool
 with pool.connect() as db_conn:
     # insert into database
-    db_conn.execute(insert_stmt, id="book1", title="Book One")
+    db_conn.execute(insert_stmt, parameters={"id": "book1", "title": "Book One"})
 
     # query database
     result = db_conn.execute(sqlalchemy.text("SELECT * from my_table")).fetchall()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@ pytest==7.2.1
 mock==5.0.1
 pytest-cov==4.0.0
 pytest-asyncio==0.20.3
-SQLAlchemy==1.4.46
+SQLAlchemy==2.0.2
 sqlalchemy-pytds==0.3.4
 flake8==5.0.4
 flake8-annotations==2.9.1

--- a/tests/system/test_connector_object.py
+++ b/tests/system/test_connector_object.py
@@ -52,7 +52,7 @@ def init_connection_engine(
 
 def test_connector_with_credentials() -> None:
     """Test Connector object connection with credentials loaded from file."""
-    credentials, project = google.auth.load_credentials_from_file(
+    credentials, _ = google.auth.load_credentials_from_file(
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
     )
     custom_connector = Connector(credentials=credentials)

--- a/tests/system/test_connector_object.py
+++ b/tests/system/test_connector_object.py
@@ -45,6 +45,7 @@ def init_connection_engine(
     pool = sqlalchemy.create_engine(
         "mysql+pymysql://",
         creator=getconn,
+        execution_options={"isolation_level": "AUTOCOMMIT"},
     )
     return pool
 

--- a/tests/system/test_connector_object.py
+++ b/tests/system/test_connector_object.py
@@ -59,7 +59,7 @@ def test_connector_with_credentials() -> None:
         pool = init_connection_engine(custom_connector)
 
         with pool.connect() as conn:
-            conn.execute("SELECT 1")
+            conn.execute(sqlalchemy.text("SELECT 1"))
 
     except Exception as e:
         logging.exception("Failed to connect with credentials from file!", e)
@@ -76,10 +76,10 @@ def test_multiple_connectors() -> None:
         pool2 = init_connection_engine(second_connector)
 
         with pool.connect() as conn:
-            conn.execute("SELECT 1")
+            conn.execute(sqlalchemy.text("SELECT 1"))
 
         with pool2.connect() as conn:
-            conn.execute("SELECT 1")
+            conn.execute(sqlalchemy.text("SELECT 1"))
 
         instance_connection_string = os.environ["MYSQL_CONNECTION_NAME"]
         assert instance_connection_string in first_connector._instances
@@ -108,7 +108,7 @@ def test_connector_in_ThreadPoolExecutor() -> None:
 
         # connect to database and get current time
         with pool.connect() as conn:
-            current_time = conn.execute("SELECT NOW()").fetchone()
+            current_time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
 
         # close connector
         default_connector.close()
@@ -127,7 +127,7 @@ def test_connector_as_context_manager() -> None:
         pool = init_connection_engine(connector)
 
         with pool.connect() as conn:
-            conn.execute("SELECT 1")
+            conn.execute(sqlalchemy.text("SELECT 1"))
 
 
 def test_connector_with_custom_loop() -> None:
@@ -141,7 +141,7 @@ def test_connector_with_custom_loop() -> None:
         pool = init_connection_engine(connector)
 
         with pool.connect() as conn:
-            result = conn.execute("SELECT 1").fetchone()
+            result = conn.execute(sqlalchemy.text("SELECT 1")).fetchone()
         assert result[0] == 1
         # assert that Connector does not start its own thread
         assert connector._thread is None

--- a/tests/system/test_ip_types.py
+++ b/tests/system/test_ip_types.py
@@ -49,7 +49,7 @@ def test_public_ip() -> None:
     with Connector() as connector:
         pool = init_connection_engine(connector, IPTypes.PUBLIC)
         with pool.connect() as conn:
-            conn.execute("SELECT 1")
+            conn.execute(sqlalchemy.text("SELECT 1"))
 
 
 @pytest.mark.private_ip
@@ -57,4 +57,4 @@ def test_private_ip() -> None:
     with Connector() as connector:
         pool = init_connection_engine(connector, IPTypes.PRIVATE)
         with pool.connect() as conn:
-            conn.execute("SELECT 1")
+            conn.execute(sqlalchemy.text("SELECT 1"))

--- a/tests/system/test_ip_types.py
+++ b/tests/system/test_ip_types.py
@@ -41,6 +41,7 @@ def init_connection_engine(
     pool = sqlalchemy.create_engine(
         "mysql+pymysql://",
         creator=getconn,
+        execution_options={"isolation_level": "AUTOCOMMIT"},
     )
     return pool
 

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -80,8 +80,8 @@ def test_pooled_connection_with_pg8000(pool: sqlalchemy.engine.Engine) -> None:
         f"INSERT INTO {table_name} (id, title) VALUES (:id, :title)",
     )
     with pool.connect() as conn:
-        conn.execute(insert_stmt, id="book1", title="Book One")
-        conn.execute(insert_stmt, id="book2", title="Book Two")
+        conn.execute(insert_stmt, parameters={"id": "book1", "title": "Book One"})
+        conn.execute(insert_stmt, parameters={"id": "book2", "title": "Book Two"})
 
     select_stmt = sqlalchemy.text(f"SELECT title FROM {table_name} ORDER BY ID;")
     with pool.connect() as conn:

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -49,6 +49,7 @@ def init_connection_engine() -> sqlalchemy.engine.Engine:
     pool = sqlalchemy.create_engine(
         "postgresql+pg8000://",
         creator=getconn,
+        execution_options={"isolation_level": "AUTOCOMMIT"},
     )
     pool.dialect.description_encoding = None
     return pool

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -63,14 +63,16 @@ def setup() -> Generator:
 
     with pool.connect() as conn:
         conn.execute(
-            f"CREATE TABLE IF NOT EXISTS {table_name}"
-            " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
+            sqlalchemy.text(
+                f"CREATE TABLE IF NOT EXISTS {table_name}"
+                " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
+            )
         )
 
     yield pool
 
     with pool.connect() as conn:
-        conn.execute(f"DROP TABLE IF EXISTS {table_name}")
+        conn.execute(sqlalchemy.text(f"DROP TABLE IF EXISTS {table_name}"))
 
 
 def test_pooled_connection_with_pg8000(pool: sqlalchemy.engine.Engine) -> None:

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -48,6 +48,7 @@ def init_connection_engine() -> sqlalchemy.engine.Engine:
     pool = sqlalchemy.create_engine(
         "postgresql+pg8000://",
         creator=getconn,
+        execution_options={"isolation_level": "AUTOCOMMIT"},
     )
     pool.dialect.description_encoding = None
     return pool

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -79,8 +79,8 @@ def test_pooled_connection_with_pg8000_iam_auth(pool: sqlalchemy.engine.Engine) 
         f"INSERT INTO {table_name} (id, title) VALUES (:id, :title)",
     )
     with pool.connect() as conn:
-        conn.execute(insert_stmt, id="book1", title="Book One")
-        conn.execute(insert_stmt, id="book2", title="Book Two")
+        conn.execute(insert_stmt, parameters={"id": "book1", "title": "Book One"})
+        conn.execute(insert_stmt, parameters={"id": "book2", "title": "Book Two"})
 
     select_stmt = sqlalchemy.text(f"SELECT title FROM {table_name} ORDER BY ID;")
     with pool.connect() as conn:

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -62,14 +62,16 @@ def setup() -> Generator:
 
     with pool.connect() as conn:
         conn.execute(
-            f"CREATE TABLE IF NOT EXISTS {table_name}"
-            " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
+            sqlalchemy.text(
+                f"CREATE TABLE IF NOT EXISTS {table_name}"
+                " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
+            )
         )
 
     yield pool
 
     with pool.connect() as conn:
-        conn.execute(f"DROP TABLE IF EXISTS {table_name}")
+        conn.execute(sqlalchemy.text(f"DROP TABLE IF EXISTS {table_name}"))
 
 
 def test_pooled_connection_with_pg8000_iam_auth(pool: sqlalchemy.engine.Engine) -> None:

--- a/tests/system/test_pymysql_connection.py
+++ b/tests/system/test_pymysql_connection.py
@@ -49,6 +49,7 @@ def init_connection_engine() -> sqlalchemy.engine.Engine:
     pool = sqlalchemy.create_engine(
         "mysql+pymysql://",
         creator=getconn,
+        execution_options={"isolation_level": "AUTOCOMMIT"},
     )
     return pool
 

--- a/tests/system/test_pymysql_connection.py
+++ b/tests/system/test_pymysql_connection.py
@@ -79,8 +79,8 @@ def test_pooled_connection_with_pymysql(pool: sqlalchemy.engine.Engine) -> None:
         f"INSERT INTO {table_name} (id, title) VALUES (:id, :title)",
     )
     with pool.connect() as conn:
-        conn.execute(insert_stmt, id="book1", title="Book One")
-        conn.execute(insert_stmt, id="book2", title="Book Two")
+        conn.execute(insert_stmt, parameters={"id": "book1", "title": "Book One"})
+        conn.execute(insert_stmt, parameters={"id": "book2", "title": "Book Two"})
 
     select_stmt = sqlalchemy.text(f"SELECT title FROM {table_name} ORDER BY ID;")
     with pool.connect() as conn:

--- a/tests/system/test_pymysql_connection.py
+++ b/tests/system/test_pymysql_connection.py
@@ -62,14 +62,16 @@ def setup() -> Generator:
 
     with pool.connect() as conn:
         conn.execute(
-            f"CREATE TABLE IF NOT EXISTS `{table_name}`"
-            " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
+            sqlalchemy.text(
+                f"CREATE TABLE IF NOT EXISTS `{table_name}`"
+                " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
+            )
         )
 
     yield pool
 
     with pool.connect() as conn:
-        conn.execute(f"DROP TABLE IF EXISTS `{table_name}`")
+        conn.execute(sqlalchemy.text(f"DROP TABLE IF EXISTS `{table_name}`"))
 
 
 def test_pooled_connection_with_pymysql(pool: sqlalchemy.engine.Engine) -> None:

--- a/tests/system/test_pymysql_iam_auth.py
+++ b/tests/system/test_pymysql_iam_auth.py
@@ -45,6 +45,7 @@ def init_connection_engine() -> sqlalchemy.engine.Engine:
     pool = sqlalchemy.create_engine(
         "mysql+pymysql://",
         creator=getconn,
+        execution_options={"isolation_level": "AUTOCOMMIT"},
     )
     return pool
 

--- a/tests/system/test_pymysql_iam_auth.py
+++ b/tests/system/test_pymysql_iam_auth.py
@@ -58,14 +58,16 @@ def setup() -> Generator:
 
     with pool.connect() as conn:
         conn.execute(
-            f"CREATE TABLE IF NOT EXISTS {table_name}"
-            " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
+            sqlalchemy.text(
+                f"CREATE TABLE IF NOT EXISTS {table_name}"
+                " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
+            )
         )
 
     yield pool
 
     with pool.connect() as conn:
-        conn.execute(f"DROP TABLE IF EXISTS {table_name}")
+        conn.execute(sqlalchemy.text(f"DROP TABLE IF EXISTS {table_name}"))
 
 
 def test_pooled_connection_with_pymysql_iam_auth(

--- a/tests/system/test_pymysql_iam_auth.py
+++ b/tests/system/test_pymysql_iam_auth.py
@@ -77,8 +77,8 @@ def test_pooled_connection_with_pymysql_iam_auth(
         f"INSERT INTO {table_name} (id, title) VALUES (:id, :title)",
     )
     with pool.connect() as conn:
-        conn.execute(insert_stmt, id="book1", title="Book One")
-        conn.execute(insert_stmt, id="book2", title="Book Two")
+        conn.execute(insert_stmt, parameters={"id": "book1", "title": "Book One"})
+        conn.execute(insert_stmt, parameters={"id": "book2", "title": "Book Two"})
 
     select_stmt = sqlalchemy.text(f"SELECT title FROM {table_name} ORDER BY ID;")
     with pool.connect() as conn:

--- a/tests/system/test_pytds_connection.py
+++ b/tests/system/test_pytds_connection.py
@@ -81,8 +81,8 @@ def test_pooled_connection_with_pytds(pool: sqlalchemy.engine.Engine) -> None:
         f"INSERT INTO {table_name} (id, title) VALUES (:id, :title)",
     )
     with pool.connect() as conn:
-        conn.execute(insert_stmt, id="book1", title="Book One")
-        conn.execute(insert_stmt, id="book2", title="Book Two")
+        conn.execute(insert_stmt, parameters={"id": "book1", "title": "Book One"})
+        conn.execute(insert_stmt, parameters={"id": "book2", "title": "Book Two"})
 
     select_stmt = sqlalchemy.text(f"SELECT title FROM {table_name} ORDER BY ID;")
     with pool.connect() as conn:

--- a/tests/system/test_pytds_connection.py
+++ b/tests/system/test_pytds_connection.py
@@ -64,14 +64,16 @@ def setup() -> Generator:
 
     with pool.connect() as conn:
         conn.execute(
-            f"CREATE TABLE {table_name}"
-            " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
+            sqlalchemy.text(
+                f"CREATE TABLE {table_name}"
+                " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
+            )
         )
 
     yield pool
 
     with pool.connect() as conn:
-        conn.execute(f"DROP TABLE {table_name}")
+        conn.execute(sqlalchemy.text(f"DROP TABLE {table_name}"))
 
 
 def test_pooled_connection_with_pytds(pool: sqlalchemy.engine.Engine) -> None:

--- a/tests/system/test_pytds_connection.py
+++ b/tests/system/test_pytds_connection.py
@@ -50,6 +50,7 @@ def init_connection_engine() -> sqlalchemy.engine.Engine:
     pool = sqlalchemy.create_engine(
         "mssql+pytds://localhost",
         creator=getconn,
+        execution_options={"isolation_level": "AUTOCOMMIT"},
     )
     pool.dialect.description_encoding = None
     return pool


### PR DESCRIPTION
SQLAlchemy major version release v2 has been released. With it comes a few new changes: 
- no raw strings can be executed, instead the use of `sqlalchemy.text()` must be used to prepare queries. This helps limit the ability for SQL injection attacks.
- Autocommit is turned off by default to reduce sub-transaction issues

Closes #596 