### PR TITLE
chore: Revert "chore: update SQL Server notebook"

### DIFF
--- a/samples/notebooks/sqlserver_python_connector.ipynb
+++ b/samples/notebooks/sqlserver_python_connector.ipynb
@@ -642,7 +642,7 @@
         "\n",
         "# create connection pool\n",
         "pool = sqlalchemy.create_engine(\n",
-        "    \"mssql+pytds://<YOUR_CLOUD_SQL_PRIVATE_IP_ADDRESS>\",\n",
+        "    \"mssql+pytds://localhost\",\n",
         "    creator=getconn,\n",
         ")\n",
         "\n",


### PR DESCRIPTION
Reverts GoogleCloudPlatform/cloud-sql-python-connector#621

It turns out that when creating a SQLAlchemy connection pool for pytds it requires a `host` value in the URI
```python
# create connection pool
pool = sqlalchemy.create_engine(
    "mssql+pytds://<HOST>",
    creator=getconn,
)
``` 

It does not actually matter what this host field's value is as the Python Connector's `getconn` that is used as the `creator` to make the connections does not take into account when connecting.

Reverting a change that made it seem like this value had to be the Private IP address of the Cloud SQL instance as it in fact does not.