### PR TITLE
chore: remove `host` param from SQL Server samples

### DIFF
--- a/samples/notebooks/sqlserver_python_connector.ipynb
+++ b/samples/notebooks/sqlserver_python_connector.ipynb
@@ -380,7 +380,7 @@
       "source": [
         "# install dependencies\n",
         "import sys\n",
-        "!{sys.executable} -m pip install cloud-sql-python-connector[\"pytds\"] SQLAlchemy==2.0.2 sqlalchemy-pytds\n"
+        "!{sys.executable} -m pip install cloud-sql-python-connector[\"pytds\"] SQLAlchemy==2.0.4 sqlalchemy-pytds==0.3.5\n"
       ],
       "execution_count": null,
       "outputs": []
@@ -472,7 +472,7 @@
         "\n",
         "# create connection pool with 'creator' argument to our connection object function\n",
         "pool = sqlalchemy.create_engine(\n",
-        "    \"mssql+pytds://localhost\",\n",
+        "    \"mssql+pytds://\",\n",
         "    creator=getconn,\n",
         ")"
       ],
@@ -642,7 +642,7 @@
         "\n",
         "# create connection pool\n",
         "pool = sqlalchemy.create_engine(\n",
-        "    \"mssql+pytds://localhost\",\n",
+        "    \"mssql+pytds://\",\n",
         "    creator=getconn,\n",
         ")\n",
         "\n",

--- a/tests/system/test_pytds_connection.py
+++ b/tests/system/test_pytds_connection.py
@@ -48,7 +48,7 @@ def init_connection_engine() -> sqlalchemy.engine.Engine:
 
     # create SQLAlchemy connection pool
     pool = sqlalchemy.create_engine(
-        "mssql+pytds://localhost",
+        "mssql+pytds://",
         creator=getconn,
     )
     pool.dialect.description_encoding = None


### PR DESCRIPTION
The latest version v0.3.5 of [sqlalchemy-pytds](https://pypi.org/project/sqlalchemy-pytds/) has fixed an issue where the `host` param in SQLAlchemy URL had to be set, it is now optional. This simplifies the samples for connecting using the Python Connector as we no longer need the placeholder `host` value of localhost in our SQLAlchemy URLs.