### PR TITLE
feat: add support for HTTP proxies

### DIFF
--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -70,10 +70,15 @@ class Connector:
         creating new event loop on background thread.
 
     :type sqladmin_api_endpoint: str
-    :param sqladmin_api_endpoint:
+    :param sqladmin_api_endpoint
         Base URL to use when calling the Cloud SQL Admin API endpoint.
         Defaults to "https://sqladmin.googleapis.com", this argument should
         only be used in development.
+
+    :type http_proxy: bool
+    :param http_proxy
+        Enables extracting proxy configuration from HTTP_PROXY, HTTPS_PROXY,
+        WS_PROXY or WSS_PROXY environment variables (all are case insensitive).
     """
 
     def __init__(
@@ -85,6 +90,7 @@ class Connector:
         loop: asyncio.AbstractEventLoop = None,
         quota_project: Optional[str] = None,
         sqladmin_api_endpoint: str = "https://sqladmin.googleapis.com",
+        http_proxy: bool = False,
     ) -> None:
         # if event loop is given, use for background tasks
         if loop:
@@ -109,6 +115,7 @@ class Connector:
         self._quota_project = quota_project
         self._sqladmin_api_endpoint = sqladmin_api_endpoint
         self._credentials = credentials
+        self._http_proxy = http_proxy
 
     def connect(
         self, instance_connection_string: str, driver: str, **kwargs: Any
@@ -205,6 +212,7 @@ class Connector:
                 enable_iam_auth,
                 self._quota_project,
                 self._sqladmin_api_endpoint,
+                self._http_proxy,
             )
             self._instances[instance_connection_string] = instance
 

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -166,6 +166,11 @@ class Instance:
         Base URL to use when calling the Cloud SQL Admin API endpoint.
         Defaults to "https://sqladmin.googleapis.com", this argument should
         only be used in development.
+
+    :type http_proxy: bool
+    :param http_proxy
+        Enables extracting proxy configuration from HTTP_PROXY, HTTPS_PROXY,
+        WS_PROXY or WSS_PROXY environment variables (all are case insensitive).
     """
 
     # asyncio.AbstractEventLoop is used because the default loop,
@@ -190,7 +195,7 @@ class Instance:
             }
             if self._quota_project:
                 headers["x-goog-user-project"] = self._quota_project
-            self.__client_session = aiohttp.ClientSession(headers=headers)
+            self.__client_session = aiohttp.ClientSession(headers=headers, trust_env=self._http_proxy)
         return self.__client_session
 
     _credentials: Optional[Credentials] = None
@@ -199,6 +204,7 @@ class Instance:
     _instance_connection_string: str
     _user_agent_string: str
     _sqladmin_api_endpoint: str
+    _http_proxy: bool
     _instance: str
     _project: str
     _region: str
@@ -218,6 +224,7 @@ class Instance:
         enable_iam_auth: bool = False,
         quota_project: str = None,
         sqladmin_api_endpoint: str = "https://sqladmin.googleapis.com",
+        http_proxy: bool = False,
     ) -> None:
         # Validate connection string
         connection_string_split = instance_connection_string.split(":")
@@ -239,6 +246,7 @@ class Instance:
         self._user_agent_string = f"{APPLICATION_NAME}/{version}+{driver_name}"
         self._quota_project = quota_project
         self._sqladmin_api_endpoint = sqladmin_api_endpoint
+        self._http_proxy = http_proxy
         self._loop = loop
         self._keys = keys
         # validate credentials type

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -195,7 +195,9 @@ class Instance:
             }
             if self._quota_project:
                 headers["x-goog-user-project"] = self._quota_project
-            self.__client_session = aiohttp.ClientSession(headers=headers, trust_env=self._http_proxy)
+            self.__client_session = aiohttp.ClientSession(
+                headers=headers, trust_env=self._http_proxy
+            )
         return self.__client_session
 
     _credentials: Optional[Credentials] = None

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -111,6 +111,7 @@ def test_Connector_Init() -> None:
     assert connector._enable_iam_auth is False
     assert connector._timeout == 30
     assert connector._credentials is None
+    assert connector._http_proxy is False
     connector.close()
 
 
@@ -121,6 +122,7 @@ def test_Connector_Init_context_manager() -> None:
         assert connector._enable_iam_auth is False
         assert connector._timeout == 30
         assert connector._credentials is None
+        assert connector._http_proxy is False
 
 
 @pytest.mark.asyncio
@@ -133,6 +135,7 @@ async def test_Connector_Init_async_context_manager() -> None:
         assert connector._enable_iam_auth is False
         assert connector._timeout == 30
         assert connector._credentials is None
+        assert connector._http_proxy is False
         assert connector._loop == loop
 
 


### PR DESCRIPTION
Add support for [aiohttp.Clientsession to enable http proxies](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support).