### PR TITLE
ci: update scorecard to skip false positive

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -51,7 +51,15 @@ jobs:
           #   - Allows the repository to include the Scorecard badge.
           #   - See https://github.com/ossf/scorecard-action#publishing-results.
           publish_results: true
-
+      
+      - name: Filter SARIF to skip false positives
+        env:
+          SCORECARD_SKIPPED_RULE_IDS: "DangerousWorkflowID"
+        run: |
+          SCORECARD_SKIPPED_RULE_IDS_JSON=$(echo $SCORECARD_SKIPPED_RULE_IDS | jq -cR 'split(",")')
+          # Trim the SARIF file to remove false positive detections
+          cat results.sarif | jq '.runs[].results |= map(select(.ruleId as $id | '$SCORECARD_SKIPPED_RULE_IDS_JSON' | all($id != .)))' > resultsFiltered.sarif
+      
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
@@ -65,4 +73,4 @@ jobs:
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@04df1262e6247151b5ac09cd2c303ac36ad3f62b # v2.2.9
         with:
-          sarif_file: results.sarif
+          sarif_file: resultsFiltered.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -53,6 +53,7 @@ jobs:
           publish_results: true
       
       - name: Filter SARIF to skip false positives
+        # filter out DangerousWorkflow alerts as they do not account for safe use of labels to trigger actions
         env:
           SCORECARD_SKIPPED_RULE_IDS: "DangerousWorkflowID"
         run: |


### PR DESCRIPTION
Filtering out `DangerousWorkflow` alerts as they do not take into account the proper use of the `tests: run` label.

Native ability to only run selected checks should be coming soon as part of: https://github.com/ossf/scorecard-action/issues/1107