### PR TITLE
ci: update scorecard to not publish results

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,8 +32,6 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
 
     steps:
       - name: "Checkout code"
@@ -46,11 +44,6 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          # Public repositories:
-          #   - Publish results to OpenSSF REST API for easy access by consumers
-          #   - Allows the repository to include the Scorecard badge.
-          #   - See https://github.com/ossf/scorecard-action#publishing-results.
-          publish_results: true
       
       - name: Filter SARIF to skip false positives
         # filter out DangerousWorkflow alerts as they do not account for safe use of labels to trigger actions


### PR DESCRIPTION
Until `scorecard-action` natively supports disabling certain checks, we must remove publishing of results so that we can filter out false positives.

Reason for this is that if you are publishing results, no custom steps can be added to workflow: https://github.com/ossf/scorecard-action/blob/main/README.md?plain=1#L21