### PR TITLE
ci: add permissions for label to be removed

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,9 @@ jobs:
   coverage:
     if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Remove PR Label
         if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,9 @@ jobs:
     if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
     name: Run lint
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Remove PR Label
         if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,8 +38,10 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Remove PR label
         if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
@@ -154,8 +156,10 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Remove PR label
         if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"


### PR DESCRIPTION
Making workflow default permissions `read-all` stopped the ability for Github Action to remove the `tests: run` label from PRs. In order to successfully remove the label, the action needs write access to issues and pull requests.