### PR TITLE
chore(ci): Track released artifacts for EO 14028 compliance.

### DIFF
--- a/.kokoro/release/release.cfg
+++ b/.kokoro/release/release.cfg
@@ -1,1 +1,10 @@
 # Format: //devtools/kokoro/config/proto/build.proto
+
+# Save artifacts for EO 14028
+action {
+  define_artifacts {
+    regex: "**/dist/*.tar.gz"
+    regex: "**/dist/*.whl"
+    strip_prefix: "github/cloud-sql-python-connector"
+  }
+}


### PR DESCRIPTION
The release job will now report dist/*.whl and dist/*.tar.gz to Kokoro using define_artifacts so that
Kokoro can generate an SBOM for this artifact.