### PR TITLE
chore: add TYPE_CHECKING for imports

### DIFF
--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -13,14 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import annotations
+
 import asyncio
 from functools import partial
 import logging
 from threading import Thread
 from types import TracebackType
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, TYPE_CHECKING
 
-from google.auth.credentials import Credentials
 import google.cloud.sql.connector.asyncpg as asyncpg
 from google.cloud.sql.connector.exceptions import ConnectorLoopError
 from google.cloud.sql.connector.instance import (
@@ -31,6 +32,9 @@ import google.cloud.sql.connector.pg8000 as pg8000
 import google.cloud.sql.connector.pymysql as pymysql
 import google.cloud.sql.connector.pytds as pytds
 from google.cloud.sql.connector.utils import format_database_user, generate_keys
+
+if TYPE_CHECKING:
+    from google.auth.credentials import Credentials
 
 logger = logging.getLogger(name=__name__)
 

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -13,8 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import annotations
+
 import asyncio
-import datetime
 from enum import Enum
 import logging
 import ssl
@@ -24,6 +25,7 @@ from typing import (
     Dict,
     Optional,
     Tuple,
+    TYPE_CHECKING,
 )
 
 import aiohttp
@@ -46,6 +48,9 @@ from google.cloud.sql.connector.refresh_utils import (
 )
 from google.cloud.sql.connector.utils import _auth_init, write_to_file
 from google.cloud.sql.connector.version import __version__ as version
+
+if TYPE_CHECKING:
+    import datetime
 
 logger = logging.getLogger(name=__name__)
 

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -13,17 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import annotations
+
 import asyncio
 import copy
 import datetime
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, TYPE_CHECKING
 
-import aiohttp
-
-import google.auth
 from google.auth.credentials import Credentials, Scoped
 import google.auth.transport.requests
+
+if TYPE_CHECKING:
+    import aiohttp
 
 logger = logging.getLogger(name=__name__)
 


### PR DESCRIPTION
Adding `if TYPE_CHECKING:` to improve runtime efficiency. `TYPE_CHECKING` is False at runtime, allowing imports  that are only used for type hints etc. to only be imported by 3rd party static type checkers (aka lint job etc).

See [Python official docs](https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING) for more details.