### PR TITLE
fix: improve timeout handling

### DIFF
--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -227,7 +227,7 @@ class Connector:
             raise KeyError(f"Driver '{driver}' is not supported.")
 
         ip_type = kwargs.pop("ip_type", self._ip_type)
-        kwargs["timeout"] = kwargs.pop("timeout", self._timeout)
+        kwargs["timeout"] = kwargs.get("timeout", self._timeout)
 
         # Host and ssl options come from the certificates and metadata, so we don't
         # want the user to specify them.

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -227,9 +227,7 @@ class Connector:
             raise KeyError(f"Driver '{driver}' is not supported.")
 
         ip_type = kwargs.pop("ip_type", self._ip_type)
-        timeout = kwargs.pop("timeout", self._timeout)
-        if "connect_timeout" in kwargs:
-            timeout = kwargs.pop("connect_timeout")
+        kwargs["timeout"] = kwargs.pop("timeout", self._timeout)
 
         # Host and ssl options come from the certificates and metadata, so we don't
         # want the user to specify them.
@@ -237,8 +235,8 @@ class Connector:
         kwargs.pop("ssl", None)
         kwargs.pop("port", None)
 
-        # helper function to wrap in timeout
-        async def get_connection() -> Any:
+        # attempt to make connection to Cloud SQL instance
+        try:
             instance_data, ip_address = await instance.connect_info(ip_type)
 
             # format `user` param for automatic IAM database authn
@@ -261,13 +259,8 @@ class Connector:
             )
             return await self._loop.run_in_executor(None, connect_partial)
 
-        # attempt to make connection to Cloud SQL instance for given timeout
-        try:
-            return await asyncio.wait_for(get_connection(), timeout)
-        except asyncio.TimeoutError:
-            raise TimeoutError(f"Connection timed out after {timeout}s")
         except Exception:
-            # with any other exception, we attempt a force refresh, then throw the error
+            # with any exception, we attempt a force refresh, then throw the error
             instance.force_refresh()
             raise
 

--- a/google/cloud/sql/connector/pymysql.py
+++ b/google/cloud/sql/connector/pymysql.py
@@ -54,8 +54,11 @@ def connect(
         socket.create_connection((ip_address, SERVER_PROXY_PORT)),
         server_hostname=ip_address,
     )
-
+    # pop timeout as timeout arg is called 'connect_timeout' for pymysql
+    timeout = kwargs.pop("timeout")
     # Create pymysql connection object and hand in pre-made connection
-    conn = pymysql.Connection(host=ip_address, defer_connect=True, **kwargs)
+    conn = pymysql.Connection(
+        host=ip_address, defer_connect=True, connect_timeout=timeout, **kwargs
+    )
     conn.connect(sock)
     return conn

--- a/google/cloud/sql/connector/pymysql.py
+++ b/google/cloud/sql/connector/pymysql.py
@@ -56,9 +56,8 @@ def connect(
     )
     # pop timeout as timeout arg is called 'connect_timeout' for pymysql
     timeout = kwargs.pop("timeout")
+    kwargs["connect_timeout"] = kwargs.get("connect_timeout", timeout)
     # Create pymysql connection object and hand in pre-made connection
-    conn = pymysql.Connection(
-        host=ip_address, defer_connect=True, connect_timeout=timeout, **kwargs
-    )
+    conn = pymysql.Connection(host=ip_address, defer_connect=True, **kwargs)
     conn.connect(sock)
     return conn

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -24,34 +24,6 @@ from google.cloud.sql.connector import Connector, create_async_connector, IPType
 from google.cloud.sql.connector.exceptions import ConnectorLoopError
 
 
-async def timeout_stub(*args: Any, **kwargs: Any) -> None:
-    """Timeout stub for Instance.connect()"""
-    # sleep 10 seconds
-    await asyncio.sleep(10)
-
-
-def test_connect_timeout() -> None:
-    """Test that connection times out after custom timeout."""
-    connect_string = "test-project:test-region:test-instance"
-
-    instance = MockInstance()
-    mock_instances = {}
-    mock_instances[connect_string] = instance
-    # stub instance to raise timeout
-    setattr(instance, "connect_info", timeout_stub)
-    # init connector
-    connector = Connector()
-    # attempt to connect with timeout set to 5s
-    with patch.dict(connector._instances, mock_instances):
-        pytest.raises(
-            TimeoutError,
-            connector.connect,
-            connect_string,
-            "pymysql",
-            timeout=5,
-        )
-
-
 def test_connect_enable_iam_auth_error() -> None:
     """Test that calling connect() with different enable_iam_auth
     argument values throws error."""

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import asyncio
-from typing import Any
 
 from mock import patch
 from mocks import MockInstance

--- a/tests/unit/test_pymysql.py
+++ b/tests/unit/test_pymysql.py
@@ -45,6 +45,7 @@ async def test_pymysql(kwargs: Any) -> None:
         "wrap_socket",
         partial(context.wrap_socket, do_handshake_on_connect=False),
     )
+    kwargs["timeout"] = 30
     with patch("pymysql.Connection") as mock_connect:
         mock_connect.return_value = MockConnection
         pymysql_connect(ip_addr, context, **kwargs)


### PR DESCRIPTION
Allow database drivers to handle timeout instead of Connector itself.

Closes #759 