### PR TITLE
feat: remove support for Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.11"]
       fail-fast: false
     permissions:
       contents: read
@@ -153,7 +153,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     permissions:
       contents: read

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8
 warn_unused_configs = True
 plugins = sqlmypy
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,17 +66,17 @@ def default(session, path):
     )
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 def unit(session):
     default(session, os.path.join("tests", "unit"))
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 def system(session):
     default(session, os.path.join("tests", "system"))
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 def test(session):
     default(session, os.path.join("tests", "unit"))
     default(session, os.path.join("tests", "system"))

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -80,7 +79,7 @@ setup(
         "pytds": ["python-tds==1.12.0"],
         "asyncpg": ["asyncpg==0.27.0"]
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
[Python 3.7 EOL is June 27th, 2023](https://endoflife.date/python)

Blocked by #723, once version 1.2.4 of the Connector is released this PR can be merged to be included in the next release (July 2023)