### PR TITLE
feat: add support for PSC connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,15 @@ with pool.connect() as db_conn:
         print(row)
 ```
 
-### Specifying Public or Private IP
+### Specifying IP Address Type
 
-The Cloud SQL Connector for Python can be used to connect to Cloud SQL instances using both public and private IP addresses. To specify which IP address to use to connect, set the `ip_type` keyword argument Possible values are `IPTypes.PUBLIC` and `IPTypes.PRIVATE`.
+The Cloud SQL Python Connector can be used to connect to Cloud SQL instances
+using both public and private IP addresses, as well as
+[Private Service Connect][psc](PSC). To specify which IP address type to connect
+with, set the `ip_type` keyword argument when initializing a `Connector()` or when
+calling `connector.connect()`. Possible values are `IPTypes.PUBLIC` (default value),
+`IPTypes.PRIVATE`, and `IPTypes.PSC`.
+
 Example:
 
 ```python
@@ -261,9 +267,14 @@ connector.connect(
 )
 ```
 
-Note: If specifying Private IP, your application must already be in the same VPC network as your Cloud SQL Instance.
+Note: If specifying Private IP or Private Service Connect, your application must be
+attached to the proper VPC network to connect to your Cloud SQL instance. For most
+applications this will require the use of a [VPC Connector][vpc-connector].
 
-### IAM Authentication
+[psc]: https://cloud.google.com/vpc/docs/private-service-connect
+[vpc-connector]: https://cloud.google.com/vpc/docs/configure-serverless-vpc-access#create-connector
+
+### Automatic IAM Database Authentication
 
 Connections using [Automatic IAM database authentication](https://cloud.google.com/sql/docs/postgres/authentication#automatic) are supported when using Postgres or MySQL drivers.
 First, make sure to [configure your Cloud SQL Instance to allow IAM authentication](https://cloud.google.com/sql/docs/postgres/create-edit-iam-instances#configure-iam-db-instance)

--- a/README.md
+++ b/README.md
@@ -256,9 +256,11 @@ with Connector() as connector:
 
 The Cloud SQL Python Connector can be used to connect to Cloud SQL instances
 using both public and private IP addresses, as well as
-[Private Service Connect][psc](PSC). To specify which IP address type to connect
+[Private Service Connect][psc] (PSC). To specify which IP address type to connect
 with, set the `ip_type` keyword argument when initializing a `Connector()` or when
-calling `connector.connect()`. Possible values are `IPTypes.PUBLIC` (default value),
+calling `connector.connect()`.
+
+Possible values for `ip_type` are `IPTypes.PUBLIC` (default value),
 `IPTypes.PRIVATE`, and `IPTypes.PSC`.
 
 Example:

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 from functools import partial
 import logging
+import socket
 from threading import Thread
 from types import TracebackType
 from typing import Any, Dict, Optional, Type, TYPE_CHECKING
@@ -238,6 +239,10 @@ class Connector:
         # attempt to make connection to Cloud SQL instance
         try:
             instance_data, ip_address = await instance.connect_info(ip_type)
+            print(ip_address)
+            # resolve DNS name into IP address for PSC
+            if ip_type.value == "PSC":
+                ip_address = socket.gethostbyname(ip_address)
 
             # format `user` param for automatic IAM database authn
             if enable_iam_auth:

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -241,8 +241,7 @@ class Connector:
             instance_data, ip_address = await instance.connect_info(ip_type)
             # resolve DNS name into IP address for PSC
             if ip_type.value == "PSC":
-                loop = asyncio.get_running_loop()
-                addr_info = await loop.getaddrinfo(
+                addr_info = await self._loop.getaddrinfo(
                     ip_address, None, family=socket.AF_INET
                 )
                 ip_address = addr_info[0][4][0]

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -242,7 +242,9 @@ class Connector:
             # resolve DNS name into IP address for PSC
             if ip_type.value == "PSC":
                 loop = asyncio.get_running_loop()
-                addr_info = await loop.getaddrinfo(ip_address, None, socket.AF_INET)
+                addr_info = await loop.getaddrinfo(
+                    ip_address, None, family=socket.AF_INET
+                )
                 ip_address = addr_info[0][4][0]
 
             # format `user` param for automatic IAM database authn

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -241,7 +241,6 @@ class Connector:
             instance_data, ip_address = await instance.connect_info(ip_type)
             # resolve DNS name into IP address for PSC
             if ip_type.value == "PSC":
-                print(socket.getaddrinfo(ip_address, None, socket.AF_INET))
                 ip_address = socket.gethostbyname(ip_address)
 
             # format `user` param for automatic IAM database authn

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -239,7 +239,6 @@ class Connector:
         # attempt to make connection to Cloud SQL instance
         try:
             instance_data, ip_address = await instance.connect_info(ip_type)
-            print(ip_address)
             # resolve DNS name into IP address for PSC
             if ip_type.value == "PSC":
                 ip_address = socket.gethostbyname(ip_address)

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -241,7 +241,9 @@ class Connector:
             instance_data, ip_address = await instance.connect_info(ip_type)
             # resolve DNS name into IP address for PSC
             if ip_type.value == "PSC":
-                ip_address = socket.gethostbyname(ip_address)
+                loop = asyncio.get_running_loop()
+                addr_info = await loop.getaddrinfo(ip_address, None, socket.AF_INET)
+                ip_address = addr_info[0][4][0]
 
             # format `user` param for automatic IAM database authn
             if enable_iam_auth:

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -241,6 +241,7 @@ class Connector:
             instance_data, ip_address = await instance.connect_info(ip_type)
             # resolve DNS name into IP address for PSC
             if ip_type.value == "PSC":
+                print(socket.getaddrinfo(ip_address, None, socket.AF_INET))
                 ip_address = socket.gethostbyname(ip_address)
 
             # format `user` param for automatic IAM database authn

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -245,7 +245,7 @@ class Connector:
             # resolve DNS name into IP address for PSC
             if ip_type.value == "PSC":
                 addr_info = await self._loop.getaddrinfo(
-                    ip_address, None, family=socket.AF_INET
+                    ip_address, None, family=socket.AF_INET, type=socket.SOCK_STREAM
                 )
                 # getaddrinfo returns a list of 5-tuples that contain socket
                 # connection info in the form

--- a/google/cloud/sql/connector/exceptions.py
+++ b/google/cloud/sql/connector/exceptions.py
@@ -63,3 +63,10 @@ class AutoIAMAuthNotSupported(Exception):
     """
 
     pass
+
+
+class DnsNameResolutionError(Exception):
+    """
+    Exception to be raised when the DnsName of a PSC connection to a
+    Cloud SQL instance can not be resolved to a proper IP address.
+    """

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -60,6 +60,7 @@ APPLICATION_NAME = "cloud-sql-python-connector"
 class IPTypes(Enum):
     PUBLIC: str = "PRIMARY"
     PRIVATE: str = "PRIVATE"
+    PSC: str = "PSC"
 
 
 class InstanceMetadata:

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -108,8 +108,16 @@ async def _get_metadata(
             f'[{project}:{region}:{instance}]: Provided region was mismatched - got region {region}, expected {ret_dict["region"]}.'
         )
 
+    ip_addresses = (
+        {ip["type"]: ip["ipAddress"] for ip in ret_dict["ipAddresses"]}
+        if "ipAddresses" in ret_dict
+        else {}
+    )
+    if "dnsName" in ret_dict:
+        ip_addresses["PSC"] = ret_dict["dnsName"]
+
     metadata = {
-        "ip_addresses": {ip["type"]: ip["ipAddress"] for ip in ret_dict["ipAddresses"]},
+        "ip_addresses": ip_addresses,
         "server_ca_cert": ret_dict["serverCaCert"]["cert"],
         "database_version": ret_dict["databaseVersion"],
     }

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -219,6 +219,7 @@ class FakeCSQLInstance:
                         datetime.datetime.utcnow() + datetime.timedelta(minutes=10)
                     ),
                 },
+                "dnsName": "abcde.12345.us-central1.sql.goog",
                 "ipAddresses": ip_addresses,
                 "region": self.region,
                 "databaseVersion": self.db_version,

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -303,7 +303,7 @@ async def test_get_preferred_ip(instance: Instance) -> None:
 
     # test PSC as preferred IP type for connection
     ip_addr = instance_metadata.get_preferred_ip(IPTypes.PSC)
-    # verify private ip address is preferred
+    # verify PSC ip address is preferred
     assert ip_addr == "abcde.12345.us-central1.sql.goog"
 
 

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -301,6 +301,10 @@ async def test_get_preferred_ip(instance: Instance) -> None:
     # verify private ip address is preferred
     assert ip_addr == "1.1.1.1"
 
+    # test PSC as preferred IP type for connection
+    ip_addr = instance_metadata.get_preferred_ip(IPTypes.PSC)
+    # verify private ip address is preferred
+    assert ip_addr == "abcde.12345.us-central1.sql.goog"
 
 @pytest.mark.asyncio
 async def test_get_preferred_ip_CloudSQLIPTypeError(instance: Instance) -> None:
@@ -319,6 +323,9 @@ async def test_get_preferred_ip_CloudSQLIPTypeError(instance: Instance) -> None:
     with pytest.raises(CloudSQLIPTypeError):
         instance_metadata.get_preferred_ip(IPTypes.PRIVATE)
 
+    # test error when PSC is missing
+    with pytest.raises(CloudSQLIPTypeError):
+        instance_metadata.get_preferred_ip(IPTypes.PSC)
 
 @pytest.mark.asyncio
 async def test_ClientResponseError(

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -306,6 +306,7 @@ async def test_get_preferred_ip(instance: Instance) -> None:
     # verify private ip address is preferred
     assert ip_addr == "abcde.12345.us-central1.sql.goog"
 
+
 @pytest.mark.asyncio
 async def test_get_preferred_ip_CloudSQLIPTypeError(instance: Instance) -> None:
     """
@@ -326,6 +327,7 @@ async def test_get_preferred_ip_CloudSQLIPTypeError(instance: Instance) -> None:
     # test error when PSC is missing
     with pytest.raises(CloudSQLIPTypeError):
         instance_metadata.get_preferred_ip(IPTypes.PSC)
+
 
 @pytest.mark.asyncio
 async def test_ClientResponseError(


### PR DESCRIPTION
Add a new IP type `IPTypes.PSC` to support connections to Cloud SQL using [private service connect](https://cloud.google.com/vpc/docs/private-service-connect).