### PR TITLE
chore: add py.typed marker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,4 +82,5 @@ setup(
     python_requires=">=3.8",
     include_package_data=True,
     zip_safe=False,
+    package_data={"google.cloud.sql.connector": ["py.typed"]},
 )


### PR DESCRIPTION
The library is fully typed, so add a marker to allow linters like mypy to pick this up as specified in PEP561.