### PR TITLE
chore: remove `event_loop` fixture

### DIFF
--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -38,19 +38,19 @@ from google.cloud.sql.connector.utils import generate_keys
 
 
 @pytest.fixture
-def test_rate_limiter(event_loop: asyncio.AbstractEventLoop) -> AsyncRateLimiter:
-    return AsyncRateLimiter(max_capacity=1, rate=1 / 2, loop=event_loop)
+def test_rate_limiter() -> AsyncRateLimiter:
+    return AsyncRateLimiter(max_capacity=1, rate=1 / 2)
 
 
 @pytest.mark.asyncio
 async def test_Instance_init(
-    fake_credentials: Credentials, event_loop: asyncio.AbstractEventLoop
+    fake_credentials: Credentials,
 ) -> None:
     """
     Test to check whether the __init__ method of Instance
     can tell if the connection string that's passed in is formatted correctly.
     """
-
+    event_loop = asyncio.get_running_loop()
     connect_string = "test-project:test-region:test-instance"
     keys = asyncio.wrap_future(
         asyncio.run_coroutine_threadsafe(generate_keys(), event_loop), loop=event_loop
@@ -71,13 +71,12 @@ async def test_Instance_init(
 
 
 @pytest.mark.asyncio
-async def test_Instance_init_bad_credentials(
-    event_loop: asyncio.AbstractEventLoop,
-) -> None:
+async def test_Instance_init_bad_credentials() -> None:
     """
     Test to check whether the __init__ method of Instance
     throws proper error for bad credentials arg type.
     """
+    event_loop = asyncio.get_running_loop()
     connect_string = "test-project:test-region:test-instance"
     keys = asyncio.wrap_future(
         asyncio.run_coroutine_threadsafe(generate_keys(), event_loop), loop=event_loop
@@ -331,14 +330,15 @@ async def test_get_preferred_ip_CloudSQLIPTypeError(instance: Instance) -> None:
 
 @pytest.mark.asyncio
 async def test_ClientResponseError(
-    fake_credentials: Credentials, event_loop: asyncio.AbstractEventLoop
+    fake_credentials: Credentials,
 ) -> None:
     """
     Test that detailed error message is applied to ClientResponseError.
     """
+    loop = asyncio.get_running_loop()
     # mock Cloud SQL Admin API calls with exceptions
     keys = asyncio.wrap_future(
-        asyncio.run_coroutine_threadsafe(generate_keys(), event_loop), loop=event_loop
+        asyncio.run_coroutine_threadsafe(generate_keys(), loop), loop=loop
     )
     get_url = "https://sqladmin.googleapis.com/sql/v1beta4/projects/my-project/instances/my-instance/connectSettings"
     post_url = "https://sqladmin.googleapis.com/sql/v1beta4/projects/my-project/instances/my-instance:generateEphemeralCert"
@@ -365,7 +365,7 @@ async def test_ClientResponseError(
                 "my-project:my-region:my-instance",
                 "pymysql",
                 keys,
-                event_loop,
+                loop,
                 credentials=fake_credentials,
             )
             await instance._current

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -335,10 +335,10 @@ async def test_ClientResponseError(
     """
     Test that detailed error message is applied to ClientResponseError.
     """
-    loop = asyncio.get_running_loop()
+    event_loop = asyncio.get_running_loop()
     # mock Cloud SQL Admin API calls with exceptions
     keys = asyncio.wrap_future(
-        asyncio.run_coroutine_threadsafe(generate_keys(), loop), loop=loop
+        asyncio.run_coroutine_threadsafe(generate_keys(), event_loop), loop=event_loop
     )
     get_url = "https://sqladmin.googleapis.com/sql/v1beta4/projects/my-project/instances/my-instance/connectSettings"
     post_url = "https://sqladmin.googleapis.com/sql/v1beta4/projects/my-project/instances/my-instance:generateEphemeralCert"
@@ -365,7 +365,7 @@ async def test_ClientResponseError(
                 "my-project:my-region:my-instance",
                 "pymysql",
                 keys,
-                loop,
+                event_loop,
                 credentials=fake_credentials,
             )
             await instance._current

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -23,13 +23,12 @@ from google.cloud.sql.connector.rate_limiter import (
 
 
 @pytest.mark.asyncio
-async def test_rate_limiter_throttles_requests(
-    event_loop: asyncio.AbstractEventLoop,
-) -> None:
+async def test_rate_limiter_throttles_requests() -> None:
     """Test to check whether rate limiter will throttle incoming requests."""
+    event_loop = asyncio.get_running_loop()
     counter = 0
     # allow 2 requests to go through every 5 seconds
-    rate_limiter = AsyncRateLimiter(max_capacity=2, rate=1 / 5, loop=event_loop)
+    rate_limiter = AsyncRateLimiter(max_capacity=2, rate=1 / 5)
 
     async def increment() -> None:
         await rate_limiter.acquire()
@@ -53,13 +52,12 @@ async def test_rate_limiter_throttles_requests(
 
 
 @pytest.mark.asyncio
-async def test_rate_limiter_completes_all_tasks(
-    event_loop: asyncio.AbstractEventLoop,
-) -> None:
+async def test_rate_limiter_completes_all_tasks() -> None:
     """Test to check all requests will go through rate limiter successfully."""
+    event_loop = asyncio.get_running_loop()
     counter = 0
     # allow 1 request to go through per second
-    rate_limiter = AsyncRateLimiter(max_capacity=1, rate=1, loop=event_loop)
+    rate_limiter = AsyncRateLimiter(max_capacity=1, rate=1)
 
     async def increment() -> None:
         await rate_limiter.acquire()


### PR DESCRIPTION
Dynamically find event loop over using event_loop fixture. Using event_loop as a fixture is being deprecated

Closes #888 