### PR TITLE
fix: refresh credentials for valid oauth2 token on each refresh

### DIFF
--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -288,7 +288,7 @@ class Instance:
 
             logger.debug(f"['{self._instance_connection_string}']: Creating context")
 
-            # refresh credentials for fresh Oauth2 token
+            # refresh credentials for fresh OAuth2 token
             request = google.auth.transport.requests.Request()
             self._credentials.refresh(request)
 

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -335,9 +335,10 @@ class Instance:
             )
             expiration = x509.not_valid_after
 
+            # for IAM authentication OAuth2 token is embedded in cert so it
+            # must still be valid for successful connection
             if self._enable_iam_auth:
-                if self._credentials is not None:
-                    token_expiration: datetime.datetime = self._credentials.expiry
+                token_expiration: datetime.datetime = self._credentials.expiry
                 if expiration > token_expiration:
                     expiration = token_expiration
 

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -88,10 +88,6 @@ async def _get_metadata(
     elif not isinstance(instance, str):
         raise TypeError(f"instance must be of type str, got {type(instance)}")
 
-    if not credentials.valid:
-        request = google.auth.transport.requests.Request()
-        credentials.refresh(request)
-
     headers = {
         "Authorization": f"Bearer {credentials.token}",
     }
@@ -180,10 +176,6 @@ async def _get_ephemeral(
         raise TypeError(f"instance must be of type str, got {type(instance)}")
     elif not isinstance(pub_key, str):
         raise TypeError(f"pub_key must be of type str, got {type(pub_key)}")
-
-    if not credentials.valid:
-        request = google.auth.transport.requests.Request()
-        credentials.refresh(request)
 
     headers = {
         "Authorization": f"Bearer {credentials.token}",


### PR DESCRIPTION
Previously, the credentials object which is used for auto IAM authentication was only refreshed when it became invalid (expired). This is buggy as the credentials expiration is sometimes used to calculate when to schedule the next refresh (when credentials expiration is sooner than cert expiration). If we do not refresh the credentials object as part of the refresh operation than we get constant refreshes scheduled in the final few minutes before the credentials' OAuth2 token expires.  

Fixes #892 