### PR TITLE
chore: make driver versions more flexible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,10 +74,10 @@ setup(
     namespace_packages=namespaces,
     install_requires=core_dependencies,
     extras_require={
-        "pymysql": ["PyMySQL==1.1.0"],
-        "pg8000": ["pg8000==1.30.3"],
-        "pytds": ["python-tds==1.13.0"],
-        "asyncpg": ["asyncpg==0.29.0"]
+        "pymysql": ["PyMySQL>=1.1.0"],
+        "pg8000": ["pg8000>=1.30.3"],
+        "pytds": ["python-tds>=1.13.0"],
+        "asyncpg": ["asyncpg>=0.29.0"]
     },
     python_requires=">=3.8",
     include_package_data=True,


### PR DESCRIPTION
Driver packages like `asyncpg` have corresponding stub libraries such as [asyncpg-stubs](https://pypi.org/project/asyncpg-stubs/) that are aggressive on forcing latest version of driver for typing. Driver versions in the Connector may be slightly out of sync as we wait for next release at our monthly cadence. Being more lenient in driver version and not forcing the version to be explicit will allow users to not run into version conflicts between connector `asyncpg` driver version and stub library `asyncpg` version.

cc @kurtisvg 