### PR TITLE
chore: explicitly add `pip_setup` to renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,9 @@
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt"]
   },
+  "pip_setup": {
+    "fileMatch": ["(^|/)setup\\.py$"]
+  },
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
For some reason #938 did update `setup.py` as it normally does.

This change explicitly adds setup.py to renovate's config, not relying on defaults. 