### PR TITLE
deps: update dependency pg8000 to v1.30.4

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,7 +13,7 @@ types-PyMySQL==1.1.0.1
 types-mock==5.1.0.3
 twine==4.0.2
 PyMySQL==1.1.0
-pg8000==1.30.3
+pg8000==1.30.4
 asyncpg==0.29.0
 python-tds==1.14.0
 aioresponses==0.7.6

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     install_requires=dependencies,
     extras_require={
         "pymysql": ["PyMySQL>=1.1.0"],
-        "pg8000": ["pg8000>=1.30.3"],
+        "pg8000": ["pg8000>=1.30.4"],
         "pytds": ["python-tds>=1.13.0"],
         "asyncpg": ["asyncpg>=0.29.0"],
     },


### PR DESCRIPTION
For some reason ever since using the syntax `>=` in setup.py #904 the file is no longer having the version of the drivers bumped in renovate PRs. 

Manually bumping for now.

Closes #951 