### PR TITLE
chore: improve connector.close

### DIFF
--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -315,12 +315,12 @@ class Connector:
             # Will attempt to safely shut down tasks for 5s
             close_future.result(timeout=5)
         # if background thread exists for Connector, clean it up
-        if self._thread.is_alive():  # type: ignore
+        if self._thread:
             if self._loop.is_running():
                 # stop event loop running in background thread
                 self._loop.call_soon_threadsafe(self._loop.stop)
             # wait for thread to finish closing (i.e. loop to stop)
-            self._thread.join()  # type: ignore
+            self._thread.join()
 
     async def close_async(self) -> None:
         """Helper function to cancel Instances' tasks

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -308,15 +308,17 @@ class Connector:
 
     def close(self) -> None:
         """Close Connector by stopping tasks and releasing resources."""
-        close_future = asyncio.run_coroutine_threadsafe(
-            self.close_async(), loop=self._loop
-        )
-        # Will attempt to safely shut down tasks for 5s
-        close_future.result(timeout=5)
+        if self._loop.is_running():
+            close_future = asyncio.run_coroutine_threadsafe(
+                self.close_async(), loop=self._loop
+            )
+            # Will attempt to safely shut down tasks for 5s
+            close_future.result(timeout=5)
         # if background thread exists for Connector, clean it up
-        if self._thread:
-            # stop event loop running in background thread
-            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._thread.is_alive():
+            if self._loop.is_running():
+                # stop event loop running in background thread
+                self._loop.call_soon_threadsafe(self._loop.stop)
             # wait for thread to finish closing (i.e. loop to stop)
             self._thread.join()
 
@@ -326,6 +328,12 @@ class Connector:
         await asyncio.gather(
             *[instance.close() for instance in self._instances.values()]
         )
+
+    def __del__(self) -> None:
+        """Close Connector as part of garbage collection"""
+        # only want to call destructor when used for sync connections
+        if self._thread:
+            self.close()
 
 
 async def create_async_connector(

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -315,12 +315,12 @@ class Connector:
             # Will attempt to safely shut down tasks for 5s
             close_future.result(timeout=5)
         # if background thread exists for Connector, clean it up
-        if self._thread.is_alive():
+        if self._thread.is_alive():  # type: ignore
             if self._loop.is_running():
                 # stop event loop running in background thread
                 self._loop.call_soon_threadsafe(self._loop.stop)
             # wait for thread to finish closing (i.e. loop to stop)
-            self._thread.join()
+            self._thread.join()  # type: ignore
 
     async def close_async(self) -> None:
         """Helper function to cancel Instances' tasks

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -137,3 +137,16 @@ def test_Connector_close_kills_thread() -> None:
     connector.close()
     # check that connector thread is no longer running
     assert connector._thread.is_alive() is False
+
+
+def test_Connector_close_called_multiple_times() -> None:
+    """Test that Connector.close can be called multiple times."""
+    # open and close Connector object
+    connector = Connector()
+    # verify background thread exists
+    assert connector._thread
+    connector.close()
+    # check that connector thread is no longer running
+    assert connector._thread.is_alive() is False
+    # call connector.close a second time
+    connector.close()


### PR DESCRIPTION
Attempting to make the `.close` of the Connector more useful and to attempt to close on garbage collection.

Garbage collection does not guarantee when something will be called. `.close()` needs to be able to be called twice in case someone explicitly closes and then garbage collection is performed.