### PR TITLE
refactor: remove loop argument from Instance

### DIFF
--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -234,7 +234,6 @@ class Connector:
                 instance_connection_string,
                 self._client,
                 self._keys,
-                self._loop,
                 enable_iam_auth,
             )
             self._instances[instance_connection_string] = instance

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,13 +138,11 @@ async def fake_client(
 
 @pytest.fixture
 async def instance(fake_client: CloudSQLClient) -> AsyncGenerator[Instance, None]:
-    loop = asyncio.get_running_loop()
     keys = asyncio.create_task(generate_keys())
     instance = Instance(
         "test-project:test-region:test-instance",
         client=fake_client,
         keys=keys,
-        loop=loop,
     )
     yield instance
     await instance.close()

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -305,7 +305,6 @@ async def test_ClientResponseError(
     """
     Test that detailed error message is applied to ClientResponseError.
     """
-    loop = asyncio.get_running_loop()
     # mock Cloud SQL Admin API calls with exceptions
     keys = asyncio.create_task(generate_keys())
     client = CloudSQLClient(
@@ -336,7 +335,6 @@ async def test_ClientResponseError(
             "my-project:my-region:my-instance",
             client,
             keys,
-            loop,
         )
         try:
             await instance._current
@@ -359,14 +357,12 @@ async def test_AutoIAMAuthNotSupportedError(fake_client: CloudSQLClient) -> None
     Test that AutoIAMAuthNotSupported exception is raised
     for SQL Server instances.
     """
-    loop = asyncio.get_running_loop()
     # generate client key pair
     keys = asyncio.create_task(generate_keys())
     instance = Instance(
         "test-project:test-region:sqlserver-instance",
         client=fake_client,
         keys=keys,
-        loop=loop,
         enable_iam_auth=True,
     )
     with pytest.raises(AutoIAMAuthNotSupported):


### PR DESCRIPTION
Barrier to async functionality is through `connect.connect_async` at which point the `Instance()` is configured. At this stage in execution flow we are already running with the given event loop so it is redundant  to pass it to  Instance and instead we should follow best practice and purely use  higher level `asyncio.create_task` which is recommended.