### PR TITLE
chore: remove destructor

### DIFF
--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -355,12 +355,6 @@ class Connector:
         if self._client:
             await self._client.close()
 
-    def __del__(self) -> None:
-        """Close Connector as part of garbage collection"""
-        # only want to call destructor when used for sync connections
-        if self._thread:
-            self.close()
-
 
 async def create_async_connector(
     ip_type: IPTypes = IPTypes.PUBLIC,


### PR DESCRIPTION
Remove `__del__` destructor for Connector as it seems to be causing timeout errors that were introduced as part of #985 

Closes #1000 