### PR TITLE
fix: add minimum version for google-auth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ dependencies = [
     "aiohttp",
     "cryptography>=42.0.0",
     "Requests",
-    "google-auth",
+    "google-auth>=2.28.0",
 ]
 
 package_root = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Need to force `google-auth` to a recent version as older versions do not have the `creds.universe_domain` attribute that was added for TPC support in google-auth.

Noticed this as the reason for https://github.com/GoogleCloudPlatform/python-docs-samples/pull/11465 tests failing