### PR TITLE
refactor: rename Instance to RefreshAheadCache

### DIFF
--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -170,15 +170,6 @@ class RefreshAheadCache:
             enable_iam_auth (bool): Enables automatic IAM database authentication
                 (Postgres and MySQL) as the default authentication method for all
                 connections.
-        :param instance_connection_string:
-            The Google Cloud SQL Instance's connection
-            string.
-        :type instance_connection_string: str
-
-        :param enable_iam_auth
-            Enables automatic IAM database authentication for Postgres or MySQL
-            instances.
-        :type enable_iam_auth: bool
         """
         # validate and parse instance connection name
         self._project, self._region, self._instance = _parse_instance_connection_name(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ from unit.mocks import FakeCredentials  # type: ignore
 from unit.mocks import FakeCSQLInstance  # type: ignore
 
 from google.cloud.sql.connector.client import CloudSQLClient
-from google.cloud.sql.connector.instance import Instance
+from google.cloud.sql.connector.instance import RefreshAheadCache
 from google.cloud.sql.connector.utils import generate_keys
 
 SCOPES = ["https://www.googleapis.com/auth/sqlservice.admin"]
@@ -137,12 +137,12 @@ async def fake_client(
 
 
 @pytest.fixture
-async def instance(fake_client: CloudSQLClient) -> AsyncGenerator[Instance, None]:
+async def cache(fake_client: CloudSQLClient) -> AsyncGenerator[RefreshAheadCache, None]:
     keys = asyncio.create_task(generate_keys())
-    instance = Instance(
+    cache = RefreshAheadCache(
         "test-project:test-region:test-instance",
         client=fake_client,
         keys=keys,
     )
-    yield instance
-    await instance.close()
+    yield cache
+    await cache.close()

--- a/tests/system/test_connector_object.py
+++ b/tests/system/test_connector_object.py
@@ -83,11 +83,11 @@ def test_multiple_connectors() -> None:
             conn.execute(sqlalchemy.text("SELECT 1"))
 
         instance_connection_string = os.environ["MYSQL_CONNECTION_NAME"]
-        assert instance_connection_string in first_connector._instances
-        assert instance_connection_string in second_connector._instances
+        assert instance_connection_string in first_connector._cache
+        assert instance_connection_string in second_connector._cache
         assert (
-            first_connector._instances[instance_connection_string]
-            != second_connector._instances[instance_connection_string]
+            first_connector._cache[instance_connection_string]
+            != second_connector._cache[instance_connection_string]
         )
     except Exception as e:
         logging.exception("Failed to connect with multiple Connector objects!", e)

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -25,18 +25,18 @@ from google.cloud.sql.connector import create_async_connector
 from google.cloud.sql.connector import IPTypes
 from google.cloud.sql.connector.client import CloudSQLClient
 from google.cloud.sql.connector.exceptions import ConnectorLoopError
-from google.cloud.sql.connector.instance import Instance
+from google.cloud.sql.connector.instance import RefreshAheadCache
 
 
 def test_connect_enable_iam_auth_error(
-    fake_credentials: Credentials, instance: Instance
+    fake_credentials: Credentials, cache: RefreshAheadCache
 ) -> None:
     """Test that calling connect() with different enable_iam_auth
     argument values throws error."""
     connect_string = "test-project:test-region:test-instance"
     connector = Connector(credentials=fake_credentials)
-    # set instance
-    connector._instances[connect_string] = instance
+    # set cache
+    connector._cache[connect_string] = cache
     # try to connect using enable_iam_auth=True, should raise error
     with pytest.raises(ValueError) as exc_info:
         connector.connect(connect_string, "pg8000", enable_iam_auth=True)
@@ -46,8 +46,8 @@ def test_connect_enable_iam_auth_error(
         "If you require both for your use case, please use a new "
         "connector.Connector object."
     )
-    # remove instance to avoid destructor warnings
-    connector._instances = {}
+    # remove cache entrry to avoid destructor warnings
+    connector._cache = {}
 
 
 def test_connect_with_unsupported_driver(fake_credentials: Credentials) -> None:


### PR DESCRIPTION
Rename `Instance` to `RefreshAheadCache` to get ready for adding a `LazyRefresh` type in the future. This will improve naming so customers are not confused by `Instance` not reflecting a Cloud SQL instance and instead being a cache of connection info to connect to a Cloud SQL instance.

Also updated `RefreshAheadCache` docstrings to match [Google style docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).