### PR TITLE
chore: update SQLAlchemy dep to include optional asyncio deps

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@ pytest==8.1.1
 mock==5.1.0
 pytest-cov==5.0.0
 pytest-asyncio==0.23.6
-SQLAlchemy==2.0.29
+SQLAlchemy[asyncio]==2.0.29
 sqlalchemy-pytds==1.0.0
 sqlalchemy-stubs==0.4
 PyMySQL==1.1.0


### PR DESCRIPTION
For SQLAlchemy async engines (asyncpg usage) there are extra dependencies to install. 

Most platforms will come with the `greenlet` package pre-installed but macOS does not, Github has stopped pre-installing on their hosted runners. To guarantee the deps are installed we can use `sqlalchemy[asyncio]`

Ref: https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#asyncio-platform-installation-notes-including-apple-m1

Fixes #1071 
Fixes #1072 