### PR TITLE
refactor: use google.auth TokenState for credentials validity

### DIFF
--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -21,8 +21,6 @@ from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
 import aiohttp
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import load_pem_x509_certificate
-from google.auth.credentials import TokenState
-from google.auth.transport import requests
 
 from google.cloud.sql.connector.refresh_utils import _downscope_credentials
 from google.cloud.sql.connector.version import __version__ as version

--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -21,7 +21,8 @@ from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
 import aiohttp
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import load_pem_x509_certificate
-import google.auth.transport.requests
+from google.auth.credentials import TokenState
+from google.auth.transport import requests
 
 from google.cloud.sql.connector.refresh_utils import _downscope_credentials
 from google.cloud.sql.connector.version import __version__ as version
@@ -113,9 +114,6 @@ class CloudSQLClient:
             addresses and their type and a string representing the
             certificate authority.
         """
-        if not self._credentials.valid:
-            request = google.auth.transport.requests.Request()
-            self._credentials.refresh(request)
 
         headers = {
             "Authorization": f"Bearer {self._credentials.token}",
@@ -176,10 +174,6 @@ class CloudSQLClient:
         """
 
         logger.debug(f"['{instance}']: Requesting ephemeral certificate")
-
-        if not self._credentials.valid:
-            request = google.auth.transport.requests.Request()
-            self._credentials.refresh(request)
 
         headers = {
             "Authorization": f"Bearer {self._credentials.token}",

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -20,7 +20,7 @@ import datetime
 import json
 import ssl
 from tempfile import TemporaryDirectory
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Literal, Optional, Tuple
 
 from aiohttp import web
 from cryptography import x509
@@ -78,7 +78,7 @@ class FakeCredentials:
         return self._universe_domain
 
     @property
-    def token_state(self):
+    def token_state(self) -> Literal[TokenState]:
         """
         Tracks the state of a token.
         FRESH: The token is valid. It is not expired or close to expired, or the token has no expiry.

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -78,7 +78,9 @@ class FakeCredentials:
         return self._universe_domain
 
     @property
-    def token_state(self) -> Literal[TokenState]:
+    def token_state(
+        self,
+    ) -> Literal[TokenState.FRESH, TokenState.STALE, TokenState.INVALID]:
         """
         Tracks the state of a token.
         FRESH: The token is valid. It is not expired or close to expired, or the token has no expiry.

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 # file containing all mocks used for Cloud SQL Python Connector unit tests
 
 import datetime
@@ -28,7 +29,9 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
+from google.auth import _helpers
 from google.auth.credentials import Credentials
+from google.auth.credentials import TokenState
 
 from google.cloud.sql.connector.connector import _DEFAULT_UNIVERSE_DOMAIN
 from google.cloud.sql.connector.utils import generate_keys
@@ -48,7 +51,7 @@ class FakeCredentials:
         # set class type to google auth Credentials
         return Credentials
 
-    def refresh(self, request: Callable) -> None:
+    def refresh(self, _: Callable) -> None:
         """Refreshes the access token."""
         self.token = "12345"
         self.expiry = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
@@ -75,13 +78,31 @@ class FakeCredentials:
         return self._universe_domain
 
     @property
-    def valid(self) -> bool:
-        """Checks the validity of the credentials.
-
-        This is True if the credentials have a token and the token
-        is not expired.
+    def token_state(self):
         """
-        return self.token is not None and not self.expired
+        Tracks the state of a token.
+        FRESH: The token is valid. It is not expired or close to expired, or the token has no expiry.
+        STALE: The token is close to expired, and should be refreshed. The token can be used normally.
+        INVALID: The token is expired or invalid. The token cannot be used for a normal operation.
+        """
+        if self.token is None:
+            return TokenState.INVALID
+
+        # Credentials that can't expire are always treated as fresh.
+        if self.expiry is None:
+            return TokenState.FRESH
+
+        expired = datetime.datetime.now(datetime.timezone.utc) >= self.expiry
+        if expired:
+            return TokenState.INVALID
+
+        is_stale = datetime.datetime.now(datetime.timezone.utc) >= (
+            self.expiry - _helpers.REFRESH_THRESHOLD
+        )
+        if is_stale:
+            return TokenState.STALE
+
+        return TokenState.FRESH
 
 
 def generate_cert(

--- a/tests/unit/test_refresh_utils.py
+++ b/tests/unit/test_refresh_utils.py
@@ -13,12 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import asyncio
 import datetime
 
 from conftest import SCOPES  # type: ignore
 import google.auth
 from google.auth.credentials import Credentials
+from google.auth.credentials import TokenState
 import google.oauth2.credentials
 from mock import Mock
 from mock import patch
@@ -32,7 +34,7 @@ from google.cloud.sql.connector.refresh_utils import _seconds_until_refresh
 @pytest.fixture
 def credentials() -> Credentials:
     credentials = Mock(spec=Credentials)
-    credentials.valid = True
+    credentials.token_state = TokenState.FRESH
     credentials.token = "12345"
     return credentials
 


### PR DESCRIPTION
In the google.auth package, it is now recommended to use `.token_state`
over `.valid` for checking validity of credentials.

Token state gives more information such as if token is stale, expired,
invalid etc.

`.valid` is now marked as deprecated ([code](https://github.com/googleapis/google-auth-library-python/blob/main/google/auth/credentials.py#L87C5-L97C59)):
```python
@property
def valid(self):
    """Checks the validity of the credentials.

    This is True if the credentials have a :attr:`token` and the token
    is not :attr:`expired`.

    .. deprecated:: v2.24.0
      Prefer checking :attr:`token_state` instead.
    """
    return self.token is not None and not self.expired
```

Closes #1048 