### PR TITLE
refactor: remove `ip_type` from connect_info

### DIFF
--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -231,31 +231,14 @@ class RefreshAheadCache:
         scheduled_task = asyncio.create_task(_refresh_task(self, delay))
         return scheduled_task
 
-    async def connect_info(
-        self,
-        ip_type: IPTypes,
-    ) -> Tuple[ConnectionInfo, str]:
-        """Retrieve instance metadata and ip address required
-        for making connection to Cloud SQL instance.
-
-        Args:
-            ip_type (IPTypes): Enum specifying type of IP address to lookup and
-                use for connection.
-
-        Returns:
-            A tuple with the first item being the ConnectionInfo instance for
-            establishing the connection, and the second item being the IP
-            address of the Cloud SQL instance matching the specified IP type.
+    async def connect_info(self) -> ConnectionInfo:
+        """Retrieves ConnectionInfo instance for establishing a secure
+        connection to the Cloud SQL instance.
         """
         logger.debug(
             f"['{self._instance_connection_string}']: Entered connect_info method"
         )
-
-        instance_data: ConnectionInfo
-
-        instance_data = await self._current
-        ip_address: str = instance_data.get_preferred_ip(ip_type)
-        return instance_data, ip_address
+        return await self._current
 
     async def close(self) -> None:
         """Cleanup function to make sure ClientSession is closed and tasks have

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -266,10 +266,11 @@ async def test_connect_info(
     """
     Test that connect_info returns current metadata and preferred IP.
     """
-    instance_metadata, ip_addr = await cache.connect_info(IPTypes.PUBLIC)
+    conn_info = await cache.connect_info()
+    ip_addr = conn_info.get_preferred_ip(IPTypes.PUBLIC)
 
-    # verify metadata and ip address
-    assert isinstance(instance_metadata, ConnectionInfo)
+    # verify connection info and ip address
+    assert isinstance(conn_info, ConnectionInfo)
     assert ip_addr == "127.0.0.1"
 
 


### PR DESCRIPTION
Remove `ip_type` from `RefreshAheadCache.connect_info()`.

The `connect_info` method should return the `ConnectionInfo`
for the given cache and that is all. 

Currently, it gets the connection info, then gets the ip address of 
the connection info and returns both. This is just not necessary as
the ConnectionInfo already contains the method to get the
preferred IP address so we should return the `ConnectionInfo` as
is and have the `Connector.connect` grab the preferred IP for a
more straightforward flow.

This matches the Go Connectors use of [`ConnectionInfo.Addr`](https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/blob/main/internal/cloudsql/instance.go#L200)