### PR TITLE
feat: add support for lazy refresh strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,14 +185,15 @@ defaults for each connection to make, you can initialize a
 `Connector` object as follows:
 
 ```python
-from google.cloud.sql.connector import Connector, IPTypes
+from google.cloud.sql.connector import Connector
 
 # Note: all parameters below are optional
 connector = Connector(
     ip_type="public",  # can also be "private" or "psc"
     enable_iam_auth=False,
     timeout=30,
-    credentials=custom_creds # google.auth.credentials.Credentials
+    credentials=custom_creds, # google.auth.credentials.Credentials
+    refresh_strategy="lazy",  # can be "lazy" or "background"
 )
 ```
 
@@ -254,6 +255,21 @@ with Connector() as connector:
             print(row)
 ```
 
+### Configuring a Lazy Refresh (Cloud Run, Cloud Functions etc.)
+
+The Connector's `refresh_strategy` argument can be set to `"lazy"` to configure
+the Python Connector to retrieve connection info lazily and as-needed.
+Otherwise, a background refresh cycle runs to retrive the connection info
+periodically. This setting is useful in environments where the CPU may be
+throttled outside of a request context, e.g., Cloud Run, Cloud Functions, etc.
+
+To set the refresh strategy, set the `refresh_strategy` keyword argument when
+initializing a `Connector`:
+
+```python
+connector = Connector(refresh_strategy="lazy")
+```
+
 ### Specifying IP Address Type
 
 The Cloud SQL Python Connector can be used to connect to Cloud SQL instances
@@ -277,7 +293,7 @@ conn = connector.connect(
 ```
 
 > [!IMPORTANT]
-> 
+>
 > If specifying Private IP or Private Service Connect (PSC), your application must be
 > attached to the proper VPC network to connect to your Cloud SQL instance. For most
 > applications this will require the use of a [VPC Connector][vpc-connector].
@@ -354,6 +370,14 @@ conn = connector.connect(
 The Python Connector can be used alongside popular Python web frameworks such
 as Flask, FastAPI, etc, to integrate Cloud SQL databases within your
 web applications.
+
+> [!NOTE]
+>
+> For serverless environments such as Cloud Functions, Cloud Run, etc, it may be
+> beneficial to initialize the `Connector` with the lazy refresh strategy.
+> i.e. `Connector(refresh_strategy="lazy")`
+>
+> See []()
 
 #### Flask-SQLAlchemy
 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ web applications.
 > beneficial to initialize the `Connector` with the lazy refresh strategy.
 > i.e. `Connector(refresh_strategy="lazy")`
 >
-> See []()
+> See [Configuring a Lazy Refresh](#configuring-a-lazy-refresh-cloud-run-cloud-functions-etc)
 
 #### Flask-SQLAlchemy
 

--- a/google/cloud/sql/connector/__init__.py
+++ b/google/cloud/sql/connector/__init__.py
@@ -17,6 +17,13 @@ limitations under the License.
 from google.cloud.sql.connector.connector import Connector
 from google.cloud.sql.connector.connector import create_async_connector
 from google.cloud.sql.connector.instance import IPTypes
+from google.cloud.sql.connector.instance import RefreshStrategy
 from google.cloud.sql.connector.version import __version__
 
-__all__ = ["__version__", "create_async_connector", "Connector", "IPTypes"]
+__all__ = [
+    "__version__",
+    "create_async_connector",
+    "Connector",
+    "IPTypes",
+    "RefreshStrategy",
+]

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -52,6 +52,23 @@ def _parse_instance_connection_name(connection_name: str) -> Tuple[str, str, str
     return connection_name_split[1], connection_name_split[3], connection_name_split[4]
 
 
+class RefreshStrategy(Enum):
+    LAZY: str = "LAZY"
+    BACKGROUND: str = "BACKGROUND"
+
+    @classmethod
+    def _missing_(cls, value: object) -> None:
+        raise ValueError(
+            f"Incorrect value for refresh_strategy, got '{value}'. Want one of: "
+            f"{', '.join([repr(m.value) for m in cls])}."
+        )
+
+    @classmethod
+    def _from_str(cls, refresh_strategy: str) -> RefreshStrategy:
+        """Convert refresh strategy from a str into RefreshStrategy."""
+        return cls(refresh_strategy.upper())
+
+
 class IPTypes(Enum):
     PUBLIC: str = "PRIMARY"
     PRIVATE: str = "PRIVATE"

--- a/google/cloud/sql/connector/lazy.py
+++ b/google/cloud/sql/connector/lazy.py
@@ -1,0 +1,81 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from typing import Tuple
+
+from google.cloud.sql.connector.client import CloudSQLClient
+from google.cloud.sql.connector.instance import _parse_instance_connection_name
+from google.cloud.sql.connector.instance import ConnectionInfo
+from google.cloud.sql.connector.instance import IPTypes
+
+
+class LazyRefreshCache:
+    """Cache that refreshes connection info when a caller requests a connection.
+
+    Only refreshes the cache when a new connection is requested and the current
+    certificate is close to or already expired.
+    """
+
+    def __init__(
+        self,
+        instance_connection_string: str,
+        client: CloudSQLClient,
+        keys: asyncio.Future,
+        enable_iam_auth: bool = False,
+    ) -> None:
+        """Initializes a LazyRefreshCache instance.
+
+        Args:
+            instance_connection_string (str): The Cloud SQL Instance's
+                connection string (also known as an instance connection name).
+            client (CloudSQLClient): The Cloud SQL Client instance.
+            keys (asyncio.Future): A future to the client's public-private key
+                pair.
+            enable_iam_auth (bool): Enables automatic IAM database authentication
+                (Postgres and MySQL) as the default authentication method for all
+                connections.
+        """
+        # validate and parse instance connection name
+        self._project, self._region, self._instance = _parse_instance_connection_name(
+            instance_connection_string
+        )
+        self._instance_connection_string = instance_connection_string
+
+        self._enable_iam_auth = enable_iam_auth
+        self._keys = keys
+        self._client = client
+        self._refresh_in_progress = asyncio.locks.Event()
+
+    async def force_refresh(self) -> None:
+        pass
+
+    async def connect_info(
+        self,
+        ip_type: IPTypes,
+    ) -> Tuple[ConnectionInfo, str]:
+        """Retrieve instance metadata and ip address required
+        for making connection to Cloud SQL instance.
+
+        Args:
+            ip_type (IPTypes): Enum specifying type of IP address to lookup and
+                use for connection.
+
+        Returns:
+            A tuple with the first item being the ConnectionInfo instance for
+            establishing the connection, and the second item being the IP
+            address of the Cloud SQL instance matching the specified IP type.
+        """
+
+        pass

--- a/google/cloud/sql/connector/lazy.py
+++ b/google/cloud/sql/connector/lazy.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import asyncio
-from typing import Tuple
+from typing import Optional, Tuple
 
 from google.cloud.sql.connector.client import CloudSQLClient
+from google.cloud.sql.connector.connection_info import ConnectionInfo
 from google.cloud.sql.connector.instance import _parse_instance_connection_name
-from google.cloud.sql.connector.instance import ConnectionInfo
 from google.cloud.sql.connector.instance import IPTypes
 
 
@@ -57,6 +57,7 @@ class LazyRefreshCache:
         self._keys = keys
         self._client = client
         self._refresh_in_progress = asyncio.locks.Event()
+        self._cached: Optional[ConnectionInfo] = None
 
     async def force_refresh(self) -> None:
         pass

--- a/google/cloud/sql/connector/lazy.py
+++ b/google/cloud/sql/connector/lazy.py
@@ -32,6 +32,8 @@ class LazyRefreshCache:
 
     Only refreshes the cache when a new connection is requested and the current
     certificate is close to or already expired.
+
+    This is the recommended option for serverless environments.
     """
 
     def __init__(

--- a/google/cloud/sql/connector/lazy.py
+++ b/google/cloud/sql/connector/lazy.py
@@ -13,12 +13,18 @@
 # limitations under the License.
 
 import asyncio
-from typing import Optional, Tuple
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+import logging
+from typing import Optional
 
 from google.cloud.sql.connector.client import CloudSQLClient
 from google.cloud.sql.connector.connection_info import ConnectionInfo
 from google.cloud.sql.connector.instance import _parse_instance_connection_name
-from google.cloud.sql.connector.instance import IPTypes
+from google.cloud.sql.connector.refresh_utils import _refresh_buffer
+
+logger = logging.getLogger(name=__name__)
 
 
 class LazyRefreshCache:
@@ -56,27 +62,69 @@ class LazyRefreshCache:
         self._enable_iam_auth = enable_iam_auth
         self._keys = keys
         self._client = client
-        self._refresh_in_progress = asyncio.locks.Event()
+        self._lock = asyncio.Lock()
         self._cached: Optional[ConnectionInfo] = None
+        self._needs_refresh = False
 
     async def force_refresh(self) -> None:
-        pass
-
-    async def connect_info(
-        self,
-        ip_type: IPTypes,
-    ) -> Tuple[ConnectionInfo, str]:
-        """Retrieve instance metadata and ip address required
-        for making connection to Cloud SQL instance.
-
-        Args:
-            ip_type (IPTypes): Enum specifying type of IP address to lookup and
-                use for connection.
-
-        Returns:
-            A tuple with the first item being the ConnectionInfo instance for
-            establishing the connection, and the second item being the IP
-            address of the Cloud SQL instance matching the specified IP type.
         """
+        Invalidates the cache and configures the next call to
+        connect_info() to retrieve a fresh ConnectionInfo instance.
+        """
+        async with self._lock:
+            self._needs_refresh = True
 
+    async def connect_info(self) -> ConnectionInfo:
+        """Retrieves ConnectionInfo instance for establishing a secure
+        connection to the Cloud SQL instance.
+        """
+        async with self._lock:
+            # If connection info is cached, check expiration.
+            # Pad expiration with a buffer to give the client plenty of time to
+            # establish a connection to the server with the certificate.
+            if (
+                self._cached
+                and not self._needs_refresh
+                and datetime.now(timezone.utc)
+                < (self._cached.expiration - timedelta(seconds=_refresh_buffer))
+            ):
+                logger.debug(
+                    f"['{self._instance_connection_string}']: Connection info "
+                    "is still valid, using cached info"
+                )
+                return self._cached
+            logger.debug(
+                f"['{self._instance_connection_string}']: Connection info "
+                "refresh operation started"
+            )
+            try:
+                conn_info = await self._client.get_connection_info(
+                    self._project,
+                    self._region,
+                    self._instance,
+                    self._keys,
+                    self._enable_iam_auth,
+                )
+            except Exception as e:
+                logger.debug(
+                    f"['{self._instance_connection_string}']: Connection info "
+                    f"refresh operation failed: {str(e)}"
+                )
+                raise
+            logger.debug(
+                f"['{self._instance_connection_string}']: Connection info "
+                "refresh operation completed successfully"
+            )
+            logger.debug(
+                f"['{self._instance_connection_string}']: Current certificate "
+                f"expiration = {str(conn_info.expiration)}"
+            )
+            self._cached = conn_info
+            self._needs_refresh = False
+            return conn_info
+
+    async def close(self) -> None:
+        """Close is a no-op and provided purely for a consistent interface with
+        other cache types.
+        """
         pass

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -13,37 +13,31 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import os
 from typing import Generator
 import uuid
 
-# [START cloud_sql_connector_postgres_pg8000_iam_auth]
 import pg8000
 import pytest
 import sqlalchemy
 
 from google.cloud.sql.connector import Connector
 
-# [END cloud_sql_connector_postgres_pg8000_iam_auth]
 
-table_name = f"books_{uuid.uuid4().hex}"
-
-
-# [START cloud_sql_connector_postgres_pg8000_iam_auth]
 # The Cloud SQL Python Connector can be used along with SQLAlchemy using the
 # 'creator' argument to 'create_engine'
-def init_connection_engine() -> sqlalchemy.engine.Engine:
+def init_connection_engine(connector: Connector) -> sqlalchemy.engine.Engine:
     # initialize Connector object for connections to Cloud SQL
     def getconn() -> pg8000.dbapi.Connection:
-        with Connector() as connector:
-            conn: pg8000.dbapi.Connection = connector.connect(
-                os.environ["POSTGRES_IAM_CONNECTION_NAME"],
-                "pg8000",
-                user=os.environ["POSTGRES_IAM_USER"],
-                db=os.environ["POSTGRES_DB"],
-                enable_iam_auth=True,
-            )
-            return conn
+        conn: pg8000.dbapi.Connection = connector.connect(
+            os.environ["POSTGRES_IAM_CONNECTION_NAME"],
+            "pg8000",
+            user=os.environ["POSTGRES_IAM_USER"],
+            db=os.environ["POSTGRES_DB"],
+            enable_iam_auth=True,
+        )
+        return conn
 
     # create SQLAlchemy connection pool
     pool = sqlalchemy.create_engine(
@@ -55,38 +49,39 @@ def init_connection_engine() -> sqlalchemy.engine.Engine:
     return pool
 
 
-# [END cloud_sql_connector_postgres_pg8000_iam_auth]
-
-
-@pytest.fixture(name="pool")
-def setup() -> Generator:
-    pool = init_connection_engine()
-
-    with pool.connect() as conn:
-        conn.execute(
-            sqlalchemy.text(
-                f"CREATE TABLE IF NOT EXISTS {table_name}"
-                " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
-            )
-        )
+@pytest.fixture
+def pool() -> Generator:
+    connector = Connector()
+    pool = init_connection_engine(connector)
 
     yield pool
 
+    connector.close()
+
+
+@pytest.fixture
+def lazy_pool() -> Generator:
+    connector = Connector(refresh_strategy="lazy")
+    pool = init_connection_engine(connector)
+
+    yield pool
+
+    connector.close()
+
+
+def test_pooled_connection_with_pg8000_iam_auth(
+    pool: sqlalchemy.engine.Engine,
+) -> None:
     with pool.connect() as conn:
-        conn.execute(sqlalchemy.text(f"DROP TABLE IF EXISTS {table_name}"))
+        result = conn.execute(sqlalchemy.text("SELECT 1;")).fetchone()
+        assert isinstance(result[0], int)
+        assert result[0] == 1
 
 
-def test_pooled_connection_with_pg8000_iam_auth(pool: sqlalchemy.engine.Engine) -> None:
-    insert_stmt = sqlalchemy.text(
-        f"INSERT INTO {table_name} (id, title) VALUES (:id, :title)",
-    )
-    with pool.connect() as conn:
-        conn.execute(insert_stmt, parameters={"id": "book1", "title": "Book One"})
-        conn.execute(insert_stmt, parameters={"id": "book2", "title": "Book Two"})
-
-    select_stmt = sqlalchemy.text(f"SELECT title FROM {table_name} ORDER BY ID;")
-    with pool.connect() as conn:
-        rows = conn.execute(select_stmt).fetchall()
-        titles = [row[0] for row in rows]
-
-    assert titles == ["Book One", "Book Two"]
+def test_lazy_connection_with_pg8000_iam_auth(
+    lazy_pool: sqlalchemy.engine.Engine,
+) -> None:
+    with lazy_pool.connect() as conn:
+        result = conn.execute(sqlalchemy.text("SELECT 1;")).fetchone()
+        assert isinstance(result[0], int)
+        assert result[0] == 1

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 import os
 from typing import Generator
-import uuid
 
 import pg8000
 import pytest

--- a/tests/unit/test_lazy.py
+++ b/tests/unit/test_lazy.py
@@ -1,0 +1,64 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+from google.cloud.sql.connector.client import CloudSQLClient
+from google.cloud.sql.connector.connection_info import ConnectionInfo
+from google.cloud.sql.connector.lazy import LazyRefreshCache
+from google.cloud.sql.connector.utils import generate_keys
+
+
+async def test_LazyRefreshCache_connect_info(fake_client: CloudSQLClient) -> None:
+    """
+    Test that LazyRefreshCache.connect_info works as expected.
+    """
+    keys = asyncio.create_task(generate_keys())
+    cache = LazyRefreshCache(
+        "test-project:test-region:test-instance",
+        client=fake_client,
+        keys=keys,
+        enable_iam_auth=False,
+    )
+    # check that cached connection info is empty
+    assert cache._cached is None
+    conn_info = await cache.connect_info()
+    # check that cached connection info is now set
+    assert isinstance(cache._cached, ConnectionInfo)
+    # check that calling connect_info uses cached info
+    conn_info2 = await cache.connect_info()
+    assert conn_info2 == conn_info
+
+
+async def test_LazyRefreshCache_force_refresh(fake_client: CloudSQLClient) -> None:
+    """
+    Test that LazyRefreshCache.force_refresh works as expected.
+    """
+    keys = asyncio.create_task(generate_keys())
+    cache = LazyRefreshCache(
+        "test-project:test-region:test-instance",
+        client=fake_client,
+        keys=keys,
+        enable_iam_auth=False,
+    )
+    conn_info = await cache.connect_info()
+    # check that cached connection info is now set
+    assert isinstance(cache._cached, ConnectionInfo)
+    await cache.force_refresh()
+    # check that calling connect_info after force_refresh gets new ConnectionInfo
+    conn_info2 = await cache.connect_info()
+    # check that new connection info was retrieved
+    assert conn_info2 != conn_info
+    assert cache._cached == conn_info2
+    await cache.close()


### PR DESCRIPTION
Add `refresh_strategy` argument to `Connector()` that allows setting
the strategy to `"lazy"` to use a lazy refresh strategy.

When creating a Connector via `Connector(refresh_strategy="lazy")`,
the connection info and ephemeral certificate will be refreshed only
when the cache certificate has expired. No background tasks run
periodically with this option, making it ideal for use in serverless
environments such as Cloud Run, Cloud Functions, etc, where the
CPU may be throttled.

Usage example:

```python
from google.cloud.sql.connector import Connector

with Connector(refresh_strategy="lazy") as connector:
    # ... use connector in lazy refresh mode
```