### PR TITLE
fix: use asyncio.Lock over Event

### DIFF
--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -120,43 +120,12 @@ class RefreshAheadCache:
             a string representing a PEM-encoded private key and a string
             representing a PEM-encoded certificate authority.
         """
-<<<<<<< HEAD
         async with self._lock:
             logger.debug(
-                f"['{self._instance_connection_string}']: Entered _perform_refresh"
-=======
-        self._refresh_in_progress.set()
-        logger.debug(
-            f"['{self._instance_connection_string}']: Connection info refresh "
-            "operation started"
-        )
-
-        try:
-            await self._refresh_rate_limiter.acquire()
-            connection_info = await self._client.get_connection_info(
-                self._project,
-                self._region,
-                self._instance,
-                self._keys,
-                self._enable_iam_auth,
-            )
-            logger.debug(
-                f"['{self._instance_connection_string}']: Connection info "
-                "refresh operation complete"
-            )
-            logger.debug(
-                f"['{self._instance_connection_string}']: Current certificate "
-                f"expiration = {connection_info.expiration.isoformat()}"
+                f"['{self._instance_connection_string}']: Connection info refresh "
+                "operation started"
             )
 
-        except aiohttp.ClientResponseError as e:
-            logger.debug(
-                f"['{self._instance_connection_string}']: Connection info "
-                f"refresh operation failed: {str(e)}"
->>>>>>> main
-            )
-
-<<<<<<< HEAD
             try:
                 await self._refresh_rate_limiter.acquire()
                 connection_info = await self._client.get_connection_info(
@@ -166,26 +135,28 @@ class RefreshAheadCache:
                     self._keys,
                     self._enable_iam_auth,
                 )
-=======
-        except Exception as e:
-            logger.debug(
-                f"['{self._instance_connection_string}']: Connection info "
-                f"refresh operation failed: {str(e)}"
-            )
-            raise
->>>>>>> main
+                logger.debug(
+                    f"['{self._instance_connection_string}']: Connection info "
+                    "refresh operation complete"
+                )
+                logger.debug(
+                    f"['{self._instance_connection_string}']: Current certificate "
+                    f"expiration = {connection_info.expiration.isoformat()}"
+                )
 
             except aiohttp.ClientResponseError as e:
                 logger.debug(
-                    f"['{self._instance_connection_string}']: Error occurred during _perform_refresh."
+                    f"['{self._instance_connection_string}']: Connection info "
+                    f"refresh operation failed: {str(e)}"
                 )
                 if e.status == 403:
                     e.message = "Forbidden: Authenticated IAM principal does not seeem authorized to make API request. Verify 'Cloud SQL Admin API' is enabled within your GCP project and 'Cloud SQL Client' role has been granted to IAM principal."
                 raise
 
-            except Exception:
+            except Exception as e:
                 logger.debug(
-                    f"['{self._instance_connection_string}']: Error occurred during _perform_refresh."
+                    f"['{self._instance_connection_string}']: Connection info "
+                    f"refresh operation failed: {str(e)}"
                 )
                 raise
         return connection_info

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -177,16 +177,16 @@ async def test_force_refresh_cancels_pending_refresh(
     test_rate_limiter: AsyncRateLimiter,
 ) -> None:
     """
-    Test that force_refresh cancels pending task if refresh_in_progress event is not set.
+    Test that force_refresh cancels pending task if lock is not acquired.
     """
     # allow more frequent refreshes for tests
     setattr(cache, "_refresh_rate_limiter", test_rate_limiter)
     # make sure initial refresh is finished
     await cache._current
-    # since the pending refresh isn't for another 55 min, the refresh_in_progress event
-    # shouldn't be set
+    # since the pending refresh isn't for another 55 min, the lock should not
+    # be acquired
     pending_refresh = cache._next
-    assert cache._refresh_in_progress.is_set() is False
+    assert cache._lock.locked() is False
 
     await cache.force_refresh()
 


### PR DESCRIPTION
We are currently improperly using [`asyncio.Event` ](https://docs.python.org/3/library/asyncio-sync.html#event) in our code. Event is meant to be used with the `wait` coroutine to hold coroutine from running until the `set()` is called. We don't use wait anywhere in our code thus this is not having the intended effect. 

Much easier to just use [`asyncio.Lock`](https://docs.python.org/3/library/asyncio-sync.html#lock) which allows usage as a context manager to acquire/release the mutex lock.