### PR TITLE
feat: add standardized debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ a `Connector` as an async context manager, removing the need for explicit
 calls to `connector.close_async()` to cleanup resources.
 
 > [!NOTE]
-> 
+>
 > This alternative requires that the running event loop be
 > passed in as the `loop` argument to `Connector()`.
 
@@ -608,6 +608,28 @@ async def main():
         # dispose of connection pool
         await pool.dispose()
 ```
+
+### Debug Logging
+
+The Cloud SQL Python Connector uses the standard [Python logging module][python-logging]
+for debug logging support.
+
+Add the below code to your application to enable debug logging with the Cloud SQL
+Python Connector:
+
+```python
+import logging
+
+logging.basicConfig(format="%(asctime)s [%(levelname)s]: %(message)s")
+logger = logging.getLogger(name="google.cloud.sql.connector")
+logger.setLevel(logging.DEBUG)
+```
+
+For more details on configuring logging, please refer to
+[Python logging docs][configure-logging].
+
+[python-logging]: https://docs.python.org/3/library/logging.html
+[configure-logging]: https://docs.python.org/3/howto/logging.html#configuring-logging
 
 ## Support policy
 

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ logger = logging.getLogger(name="google.cloud.sql.connector")
 logger.setLevel(logging.DEBUG)
 ```
 
-For more details on configuring logging, please refer to
+For more details on configuring logging, please refer to the
 [Python logging docs][configure-logging].
 
 [python-logging]: https://docs.python.org/3/library/logging.html

--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -290,4 +290,6 @@ class CloudSQLClient:
 
     async def close(self) -> None:
         """Close CloudSQLClient gracefully."""
+        logger.debug(f"Waiting for Connector's http client to close")
         await self._client.close()
+        logger.debug(f"Closed Connector's http client")

--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -290,6 +290,6 @@ class CloudSQLClient:
 
     async def close(self) -> None:
         """Close CloudSQLClient gracefully."""
-        logger.debug(f"Waiting for Connector's http client to close")
+        logger.debug("Waiting for Connector's http client to close")
         await self._client.close()
-        logger.debug(f"Closed Connector's http client")
+        logger.debug("Closed Connector's http client")

--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -124,8 +124,6 @@ class CloudSQLClient:
 
         url = f"{self._sqladmin_api_endpoint}/sql/{API_VERSION}/projects/{project}/instances/{instance}/connectSettings"
 
-        logger.debug(f"['{instance}']: Requesting metadata")
-
         resp = await self._client.get(url, headers=headers, raise_for_status=True)
         ret_dict = await resp.json()
 
@@ -175,9 +173,6 @@ class CloudSQLClient:
         :returns: An ephemeral certificate from the Cloud SQL instance that allows
             authorized connections to the instance.
         """
-
-        logger.debug(f"['{instance}']: Requesting ephemeral certificate")
-
         headers = {
             "Authorization": f"Bearer {self._credentials.token}",
         }

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -278,6 +278,10 @@ class Connector:
                 )
         else:
             if self._refresh_strategy == RefreshStrategy.LAZY:
+                logger.debug(
+                    f"['{instance_connection_string}']: Refresh strategy is set"
+                    " to lazy refresh"
+                )
                 cache = LazyRefreshCache(
                     instance_connection_string,
                     self._client,
@@ -285,12 +289,19 @@ class Connector:
                     enable_iam_auth,
                 )
             else:
+                logger.debug(
+                    f"['{instance_connection_string}']: Refresh strategy is set"
+                    " to backgound refresh"
+                )
                 cache = RefreshAheadCache(
                     instance_connection_string,
                     self._client,
                     self._keys,
                     enable_iam_auth,
                 )
+            logger.debug(
+                f"['{instance_connection_string}']: Connection info added to cache"
+            )
             self._cache[instance_connection_string] = cache
 
         connect_func = {
@@ -337,7 +348,9 @@ class Connector:
                     raise DnsNameResolutionError(
                         f"['{instance_connection_string}']: DNS name could not be resolved into IP address"
                     ) from e
-
+            logger.debug(
+                f"['{instance_connection_string}']: Connecting to {ip_address}:3307"
+            )
             # format `user` param for automatic IAM database authn
             if enable_iam_auth:
                 formatted_user = format_database_user(

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -221,9 +221,6 @@ class RefreshAheadCache:
             refresh_task: asyncio.Task
             try:
                 if delay > 0:
-                    logger.debug(
-                        f"['{self._instance_connection_string}']: Entering sleep"
-                    )
                     await asyncio.sleep(delay)
                 refresh_task = asyncio.create_task(self._perform_refresh())
                 refresh_data = await refresh_task

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -260,7 +260,7 @@ class RefreshAheadCache:
             logger.debug(
                 f"['{self._instance_connection_string}']: Connection info refresh"
                 " operation scheduled for "
-                f"{(datetime.now(timezone.utc)+timedelta(seconds=delay)).isoformat(timespec='seconds')} "
+                f"{(datetime.now(timezone.utc) + timedelta(seconds=delay)).isoformat(timespec='seconds')} "
                 f"(now + {timedelta(seconds=delay)})"
             )
             self._next = self._schedule_refresh(delay)

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -234,7 +234,8 @@ class RefreshAheadCache:
                     )
             except asyncio.CancelledError:
                 logger.debug(
-                    f"['{self._instance_connection_string}']: Schedule refresh task cancelled."
+                    f"['{self._instance_connection_string}']: Scheduled refresh"
+                    " operation cancelled"
                 )
                 raise
             # bad refresh attempt

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -277,20 +277,15 @@ class RefreshAheadCache:
         return await self._current
 
     async def close(self) -> None:
-        """Cleanup function to make sure ClientSession is closed and tasks have
-        finished to have a graceful exit.
+        """Cleanup function to make sure tasks have finished to have a
+        graceful exit.
         """
         logger.debug(
-            f"['{self._instance_connection_string}']: Waiting for _current to be cancelled"
+            f"['{self._instance_connection_string}']: Canceling connection info "
+            "refresh operation tasks"
         )
         self._current.cancel()
-        logger.debug(
-            f"['{self._instance_connection_string}']: Waiting for _next to be cancelled"
-        )
         self._next.cancel()
-        logger.debug(
-            f"['{self._instance_connection_string}']: Waiting for _client_session to close"
-        )
         # gracefully wait for tasks to cancel
         tasks = asyncio.gather(self._current, self._next, return_exceptions=True)
         await asyncio.wait_for(tasks, timeout=2.0)

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -258,7 +258,7 @@ class RefreshAheadCache:
             delay = _seconds_until_refresh(refresh_data.expiration)
             logger.debug(
                 f"['{self._instance_connection_string}']: Connection info refresh"
-                " operation scheduled at "
+                " operation scheduled for "
                 f"{(datetime.now(timezone.utc)+timedelta(seconds=delay)).isoformat(timespec='seconds')} "
                 f"(now + {timedelta(seconds=delay)})"
             )


### PR DESCRIPTION
Standardize optional debug logging across Cloud SQL Connector packages.

To print debug logs for the Python Connector package add the following to your application:

```python
import logging

logging.basicConfig(format="%(asctime)s [%(levelname)s]: %(message)s")
logger = logging.getLogger(name="google.cloud.sql.connector")
logger.setLevel(logging.DEBUG)
```

Example of the debug logs produced:

```sh
2024-05-31 18:27:30,472 [DEBUG]: ['my-project:my-region:my-instance']: Refresh strategy is set to backgound refresh
2024-05-31 18:27:30,473 [DEBUG]: ['my-project:my-region:my-instance']: Connection info added to cache
2024-05-31 18:27:30,473 [DEBUG]: ['my-project:my-region:my-instance']: Connection info refresh operation started
2024-05-31 18:27:30,771 [DEBUG]: ['my-project:my-region:my-instance']: Connection info refresh operation complete
2024-05-31 18:27:30,771 [DEBUG]: ['my-project:my-region:my-instance']: Current certificate expiration = 2024-05-31T19:27:30+00:00
2024-05-31 18:27:30,772 [DEBUG]: ['my-project:my-region:my-instance']: Connection info refresh operation scheduled for 2024-05-31T19:23:29+00:00 (now + 0:55:59)
2024-05-31 18:27:30,772 [DEBUG]: ['my-project:my-region:my-instance']: Connecting to X.X.X.X:3307
2024-05-31 18:27:31,508 [DEBUG]: ['my-project:my-region:my-instance']: Canceling connection info refresh operation tasks
2024-05-31 18:27:31,509 [DEBUG]: ['my-project:my-region:my-instance']: Scheduled refresh operation cancelled
2024-05-31 18:27:31,509 [DEBUG]: Waiting for Connector http client to close
2024-05-31 18:27:31,509 [DEBUG]: Closed Connector http client
```

Currently debug logging the following:
- When a refresh operation starts
- When a refresh operation finishes
- When a refresh operation errors
- When a refresh operation is canceled
- The ephemeral certificate’s expiration time
- The next scheduled refresh
- Adding connection info to the cache
- The IP address connection is being made to


Fixes #1035 