### PR TITLE
refactor: move all enums to enum.py

### DIFF
--- a/google/cloud/sql/connector/__init__.py
+++ b/google/cloud/sql/connector/__init__.py
@@ -16,8 +16,8 @@ limitations under the License.
 
 from google.cloud.sql.connector.connector import Connector
 from google.cloud.sql.connector.connector import create_async_connector
-from google.cloud.sql.connector.instance import IPTypes
-from google.cloud.sql.connector.instance import RefreshStrategy
+from google.cloud.sql.connector.enums import IPTypes
+from google.cloud.sql.connector.enums import RefreshStrategy
 from google.cloud.sql.connector.version import __version__
 
 __all__ = [

--- a/google/cloud/sql/connector/connection_info.py
+++ b/google/cloud/sql/connector/connection_info.py
@@ -27,7 +27,7 @@ from google.cloud.sql.connector.utils import write_to_file
 if TYPE_CHECKING:
     import datetime
 
-    from google.cloud.sql.connector.instance import IPTypes
+    from google.cloud.sql.connector.enums import IPTypes
 
 logger = logging.getLogger(name=__name__)
 

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -31,11 +31,11 @@ from google.auth.credentials import with_scopes_if_required
 import google.cloud.sql.connector.asyncpg as asyncpg
 from google.cloud.sql.connector.client import CloudSQLClient
 from google.cloud.sql.connector.enums import DriverMapping
+from google.cloud.sql.connector.enums import IPTypes
+from google.cloud.sql.connector.enums import RefreshStrategy
 from google.cloud.sql.connector.exceptions import ConnectorLoopError
 from google.cloud.sql.connector.exceptions import DnsNameResolutionError
-from google.cloud.sql.connector.instance import IPTypes
 from google.cloud.sql.connector.instance import RefreshAheadCache
-from google.cloud.sql.connector.instance import RefreshStrategy
 from google.cloud.sql.connector.lazy import LazyRefreshCache
 import google.cloud.sql.connector.pg8000 as pg8000
 import google.cloud.sql.connector.pymysql as pymysql

--- a/google/cloud/sql/connector/enums.py
+++ b/google/cloud/sql/connector/enums.py
@@ -12,9 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from enum import Enum
 
 from google.cloud.sql.connector.exceptions import IncompatibleDriverError
+
+
+class RefreshStrategy(Enum):
+    LAZY: str = "LAZY"
+    BACKGROUND: str = "BACKGROUND"
+
+    @classmethod
+    def _missing_(cls, value: object) -> None:
+        raise ValueError(
+            f"Incorrect value for refresh_strategy, got '{value}'. Want one of: "
+            f"{', '.join([repr(m.value) for m in cls])}."
+        )
+
+    @classmethod
+    def _from_str(cls, refresh_strategy: str) -> RefreshStrategy:
+        """Convert refresh strategy from a str into RefreshStrategy."""
+        return cls(refresh_strategy.upper())
+
+
+class IPTypes(Enum):
+    PUBLIC: str = "PRIMARY"
+    PRIVATE: str = "PRIVATE"
+    PSC: str = "PSC"
+
+    @classmethod
+    def _missing_(cls, value: object) -> None:
+        raise ValueError(
+            f"Incorrect value for ip_type, got '{value}'. Want one of: "
+            f"{', '.join([repr(m.value) for m in cls])}, 'PUBLIC'."
+        )
+
+    @classmethod
+    def _from_str(cls, ip_type_str: str) -> IPTypes:
+        """Convert IP type from a str into IPTypes."""
+        if ip_type_str.upper() == "PUBLIC":
+            ip_type_str = "PRIMARY"
+        return cls(ip_type_str.upper())
 
 
 class DriverMapping(Enum):

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -20,7 +20,6 @@ import asyncio
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
-from enum import Enum
 import logging
 import re
 from typing import Tuple
@@ -53,43 +52,6 @@ def _parse_instance_connection_name(connection_name: str) -> Tuple[str, str, str
         )
     connection_name_split = CONN_NAME_REGEX.split(connection_name)
     return connection_name_split[1], connection_name_split[3], connection_name_split[4]
-
-
-class RefreshStrategy(Enum):
-    LAZY: str = "LAZY"
-    BACKGROUND: str = "BACKGROUND"
-
-    @classmethod
-    def _missing_(cls, value: object) -> None:
-        raise ValueError(
-            f"Incorrect value for refresh_strategy, got '{value}'. Want one of: "
-            f"{', '.join([repr(m.value) for m in cls])}."
-        )
-
-    @classmethod
-    def _from_str(cls, refresh_strategy: str) -> RefreshStrategy:
-        """Convert refresh strategy from a str into RefreshStrategy."""
-        return cls(refresh_strategy.upper())
-
-
-class IPTypes(Enum):
-    PUBLIC: str = "PRIMARY"
-    PRIVATE: str = "PRIVATE"
-    PSC: str = "PSC"
-
-    @classmethod
-    def _missing_(cls, value: object) -> None:
-        raise ValueError(
-            f"Incorrect value for ip_type, got '{value}'. Want one of: "
-            f"{', '.join([repr(m.value) for m in cls])}, 'PUBLIC'."
-        )
-
-    @classmethod
-    def _from_str(cls, ip_type_str: str) -> IPTypes:
-        """Convert IP type from a str into IPTypes."""
-        if ip_type_str.upper() == "PUBLIC":
-            ip_type_str = "PRIMARY"
-        return cls(ip_type_str.upper())
 
 
 class RefreshAheadCache:

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -26,12 +26,12 @@ from mock import patch
 import mocks
 import pytest  # noqa F401 Needed to run the tests
 
+from google.cloud.sql.connector import IPTypes
 from google.cloud.sql.connector.client import CloudSQLClient
 from google.cloud.sql.connector.connection_info import ConnectionInfo
 from google.cloud.sql.connector.exceptions import AutoIAMAuthNotSupported
 from google.cloud.sql.connector.exceptions import CloudSQLIPTypeError
 from google.cloud.sql.connector.instance import _parse_instance_connection_name
-from google.cloud.sql.connector.instance import IPTypes
 from google.cloud.sql.connector.instance import RefreshAheadCache
 from google.cloud.sql.connector.rate_limiter import AsyncRateLimiter
 from google.cloud.sql.connector.refresh_utils import _is_valid


### PR DESCRIPTION
Moving enum types to file`enums.py`.

`IPTypes` and `RefreshStrategy` are shared and as such should
 not be in `instance.py` as it holds mostly RefreshAheadCache code.