### PR TITLE
fix: let DNS resolve outside connector

### DIFF
--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -140,8 +140,7 @@ class CloudSQLClient:
         # Remove trailing period from PSC DNS name.
         psc_dns = ret_dict.get("dnsName")
         if psc_dns:
-            psc_dns = psc_dns.rstrip(".")
-            ip_addresses["PSC"] = psc_dns
+            ip_addresses["PSC"] = psc_dns.rstrip(".")
 
         return {
             "ip_addresses": ip_addresses,

--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -137,8 +137,11 @@ class CloudSQLClient:
             if "ipAddresses" in ret_dict
             else {}
         )
-        if "dnsName" in ret_dict:
-            ip_addresses["PSC"] = ret_dict["dnsName"]
+        # Remove trailing period from PSC DNS name.
+        psc_dns = ret_dict.get("dnsName")
+        if psc_dns:
+            psc_dns = psc_dns.rstrip(".")
+            ip_addresses["PSC"] = psc_dns
 
         return {
             "ip_addresses": ip_addresses,

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -351,21 +351,6 @@ class Connector:
             # the cache and re-raise the error
             await self._remove_cached(instance_connection_string)
             raise
-        # resolve DNS name into IP address for PSC
-        if ip_type.value == "PSC":
-            addr_info = await self._loop.getaddrinfo(
-                ip_address, None, family=socket.AF_INET, type=socket.SOCK_STREAM
-            )
-            # getaddrinfo returns a list of 5-tuples that contain socket
-            # connection info in the form
-            # (family, type, proto, canonname, sockaddr), where sockaddr is a
-            # 2-tuple in the form (ip_address, port)
-            try:
-                ip_address = addr_info[0][4][0]
-            except IndexError as e:
-                raise DnsNameResolutionError(
-                    f"['{instance_connection_string}']: DNS name could not be resolved into IP address"
-                ) from e
         logger.debug(
             f"['{instance_connection_string}']: Connecting to {ip_address}:3307"
         )

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -34,7 +34,6 @@ from google.cloud.sql.connector.enums import DriverMapping
 from google.cloud.sql.connector.enums import IPTypes
 from google.cloud.sql.connector.enums import RefreshStrategy
 from google.cloud.sql.connector.exceptions import ConnectorLoopError
-from google.cloud.sql.connector.exceptions import DnsNameResolutionError
 from google.cloud.sql.connector.instance import RefreshAheadCache
 from google.cloud.sql.connector.lazy import LazyRefreshCache
 import google.cloud.sql.connector.pg8000 as pg8000
@@ -263,8 +262,6 @@ class Connector:
                 and then subsequent attempt with IAM database authentication.
             KeyError: Unsupported database driver Must be one of pymysql, asyncpg,
                 pg8000, and pytds.
-            DnsNameResolutionError: Could not resolve PSC IP address from DNS
-                host name.
         """
         if self._keys is None:
             self._keys = asyncio.create_task(generate_keys())

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import asyncio
 from functools import partial
 import logging
-import socket
 from threading import Thread
 from types import TracebackType
 from typing import Any, Dict, Optional, Type, Union

--- a/google/cloud/sql/connector/exceptions.py
+++ b/google/cloud/sql/connector/exceptions.py
@@ -57,13 +57,6 @@ class AutoIAMAuthNotSupported(Exception):
     pass
 
 
-class DnsNameResolutionError(Exception):
-    """
-    Exception to be raised when the DnsName of a PSC connection to a
-    Cloud SQL instance can not be resolved to a proper IP address.
-    """
-
-
 class RefreshNotValidError(Exception):
     """
     Exception to be raised when the task returned from refresh is not valid.


### PR DESCRIPTION
Python's `SSLContext` requires trailing dot to be stripped from DNS
names in order to properly configure SSL/TLS.

Previously, we were resolving the DNS and connecting to the PSC
endpoint within the Connector. However, this was a poor workaround
as we should really just strip the trailing dot and allow the drivers to
resolve the DNS on connection.