### PR TITLE
ci: fix lint issue

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -44,6 +44,7 @@ def lint(session):
         ISORT_VERSION,
         "twine",
         "build",
+        "importlib_metadata==7.2.1",
     )
     session.run(
         "isort",


### PR DESCRIPTION
Twine with `importlib_metadata==8.0` is causing issues https://github.com/pypa/twine/issues/977

Setting it to lower version to have lint job pass