### PR TITLE
fix: retry 50x errors with exponential backoff

### DIFF
--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -128,8 +128,7 @@ class CloudSQLClient:
         resp = await self._client.get(url, headers=headers)
         if resp.status >= 500:
             resp = await retry_50x(self._client.get, url, headers=headers)
-        if resp.status >= 400:
-            resp.raise_for_status()
+        resp.raise_for_status()
         ret_dict = await resp.json()
 
         if ret_dict["region"] != region:
@@ -196,8 +195,7 @@ class CloudSQLClient:
         resp = await self._client.post(url, headers=headers, json=data)
         if resp.status >= 500:
             resp = await retry_50x(self._client.post, url, headers=headers, json=data)
-        if resp.status >= 400:
-            resp.raise_for_status()
+        resp.raise_for_status()
         ret_dict = await resp.json()
 
         ephemeral_cert: str = ret_dict["ephemeralCert"]["cert"]

--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -125,7 +125,9 @@ class CloudSQLClient:
 
         url = f"{self._sqladmin_api_endpoint}/sql/{API_VERSION}/projects/{project}/instances/{instance}/connectSettings"
 
-        resp = await retry_50x(self._client.get, url, headers=headers)
+        resp = await self._client.get(url, headers=headers)
+        if resp.status >= 500:
+            resp = await retry_50x(self._client.get, url, headers=headers)
         if resp.status >= 400:
             resp.raise_for_status()
         ret_dict = await resp.json()
@@ -191,7 +193,9 @@ class CloudSQLClient:
             login_creds = _downscope_credentials(self._credentials)
             data["access_token"] = login_creds.token
 
-        resp = await retry_50x(self._client.post, url, headers=headers, json=data)
+        resp = await self._client.post(url, headers=headers, json=data)
+        if resp.status >= 500:
+            resp = await retry_50x(self._client.post, url, headers=headers, json=data)
         if resp.status >= 400:
             resp.raise_for_status()
         ret_dict = await resp.json()

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -21,8 +21,9 @@ import copy
 import datetime
 import logging
 import random
-from typing import Callable, Coroutine, List
+from typing import Any, Callable, List
 
+import aiohttp
 from google.auth.credentials import Credentials
 from google.auth.credentials import Scoped
 import google.auth.transport.requests
@@ -136,7 +137,9 @@ def _exponential_backoff(attempt: int) -> float:
     return base * pow(multi, exp)
 
 
-async def retry_50x(request_coro: Coroutine, *args, **kwargs):
+async def retry_50x(
+    request_coro: Callable, *args: Any, **kwargs: Any
+) -> aiohttp.ClientResponse:
     """Retry any 50x HTTP response up to X number of times."""
     max_retries = 5
     for i in range(max_retries):

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -146,6 +146,7 @@ async def retry_50x(request_coro: Coroutine, *args, **kwargs):
             # if max_retries has been exhausted,raise error
             if i == max_retries:
                 return resp
+            # calculate backoff time
             backoff = _exponential_backoff(i)
             await asyncio.sleep(backoff / 1000)
         else:

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -115,7 +115,7 @@ def _exponential_backoff(attempt: int) -> float:
 
     base * multi^(attempt + 1 + random)
 
-    With base = 200ms and multi = 1.1618, and random = [0.0, 1.0),
+    With base = 200ms and multi = 1.618, and random = [0.0, 1.0),
     the backoff values would fall between the following low and high ends:
 
     Attempt  Low (ms)  High (ms)
@@ -131,7 +131,7 @@ def _exponential_backoff(attempt: int) -> float:
     the fifth succeeding).
     """
     base = 200
-    multi = 1.1618
+    multi = 1.618
     exp = attempt + 1 + random.random()
     return base * pow(multi, exp)
 

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -142,10 +142,7 @@ async def retry_50x(request_coro: Coroutine, *args, **kwargs):
     for i in range(max_retries):
         resp = await request_coro(*args, **kwargs)
         # backoff for any 50X errors
-        if resp.status >= 500:
-            # if max_retries has been exhausted,raise error
-            if i == max_retries:
-                return resp
+        if resp.status >= 500 and i < max_retries:
             # calculate backoff time
             backoff = _exponential_backoff(i)
             await asyncio.sleep(backoff / 1000)

--- a/tests/unit/test_refresh_utils.py
+++ b/tests/unit/test_refresh_utils.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from __future__ import annotations
+
 import asyncio
 import datetime
 
@@ -172,28 +174,28 @@ def test_exponential_backoff(attempt: int, low: int, high: int) -> None:
 
 
 class RetryClass:
-    def __init__(self):
+    def __init__(self) -> None:
         self.attempts = 0
 
-    async def fake_request(self, status: int):
+    async def fake_request(self, status: int) -> RetryClass:
         self.status = status
         self.attempts += 1
         return self
 
 
-async def test_retry_50x_with_503():
+async def test_retry_50x_with_503() -> None:
     fake_client = RetryClass()
     resp = await retry_50x(fake_client.fake_request, 503)
     assert resp.attempts == 5
 
 
-async def test_retry_50x_with_200():
+async def test_retry_50x_with_200() -> None:
     fake_client = RetryClass()
     resp = await retry_50x(fake_client.fake_request, 200)
     assert resp.attempts == 1
 
 
-async def test_retry_50x_with_400():
+async def test_retry_50x_with_400() -> None:
     fake_client = RetryClass()
     resp = await retry_50x(fake_client.fake_request, 400)
     assert resp.attempts == 1


### PR DESCRIPTION
This commit adds retry behavior to the two SQL Admin API calls. 

Any response that results in a 50x error will now be retried up to
5 times with exponential backoff and jitter between each attempt.

The formula used to calculate the duration to wait is:

200ms * 1.618^(attempt + jitter)

This calculation matches what the Cloud SQL Proxy v1 did and
will not trigger any significant change in load on the backend.