### PR TITLE
chore: skip integration tests on forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ permissions: read-all
 jobs:
   integration:
     name: integration tests
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Google Auth Github action can not run on fork PRs as `id-token` is scoped to read only.

To unblock renovate bot PRs and external PRs we will skip integration tests for the time being from forks.