### PR TITLE
ci: update integration test logic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ permissions: read-all
 jobs:
   integration:
     name: integration tests
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,9 @@ jobs:
   integration:
     name: integration tests
     # run integration tests on all builds except pull requests from forks or dependabot
-    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+    if: |
+      github.event_name != 'pull_request' || 
+      (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ permissions: read-all
 jobs:
   integration:
     name: integration tests
+    # run integration tests on all builds except pull requests from forks or dependabot
     if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Pull request from forks once merged will still be skipped `github.event.pull_request.head.repo.full_name` will still be that of the fork.

To combat this we run the job on all events that are not a pull_request (aka `schedule` and `push`)