### PR TITLE
feat: add support for CAS-based instances

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,8 @@ jobs:
             POSTGRES_IAM_USER:${{ vars.GOOGLE_CLOUD_PROJECT }}/POSTGRES_USER_IAM_PYTHON
             POSTGRES_PASS:${{ vars.GOOGLE_CLOUD_PROJECT }}/POSTGRES_PASS
             POSTGRES_DB:${{ vars.GOOGLE_CLOUD_PROJECT }}/POSTGRES_DB
+            POSTGRES_CAS_CONNECTION_NAME:${{ vars.GOOGLE_CLOUD_PROJECT }}/POSTGRES_CAS_CONNECTION_NAME
+            POSTGRES_CAS_PASS:${{ vars.GOOGLE_CLOUD_PROJECT }}/POSTGRES_CAS_PASS
             SQLSERVER_CONNECTION_NAME:${{ vars.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_CONNECTION_NAME
             SQLSERVER_USER:${{ vars.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_USER
             SQLSERVER_PASS:${{ vars.GOOGLE_CLOUD_PROJECT }}/SQLSERVER_PASS
@@ -98,6 +100,8 @@ jobs:
           POSTGRES_IAM_USER: "${{ steps.secrets.outputs.POSTGRES_IAM_USER }}"
           POSTGRES_PASS: "${{ steps.secrets.outputs.POSTGRES_PASS }}"
           POSTGRES_DB: "${{ steps.secrets.outputs.POSTGRES_DB }}"
+          POSTGRES_CAS_CONNECTION_NAME: "${{ steps.secrets.outputs.POSTGRES_CAS_CONNECTION_NAME }}"
+          POSTGRES_CAS_PASS: "${{ steps.secrets.outputs.POSTGRES_CAS_PASS }}"
           SQLSERVER_CONNECTION_NAME: "${{ steps.secrets.outputs.SQLSERVER_CONNECTION_NAME }}"
           SQLSERVER_USER: "${{ steps.secrets.outputs.SQLSERVER_USER }}"
           SQLSERVER_PASS: "${{ steps.secrets.outputs.SQLSERVER_PASS }}"

--- a/google/cloud/sql/connector/asyncpg.py
+++ b/google/cloud/sql/connector/asyncpg.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 async def connect(
-    ip_address: str, ctx: ssl.SSLContext, **kwargs: Any
+    ip_address: str, ctx: ssl.SSLContext, server_name: str, **kwargs: Any
 ) -> "asyncpg.Connection":
     """Helper function to create an asyncpg DB-API connection object.
 

--- a/google/cloud/sql/connector/asyncpg.py
+++ b/google/cloud/sql/connector/asyncpg.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import ssl
 from typing import Any, TYPE_CHECKING
 
@@ -27,20 +28,18 @@ async def connect(
 ) -> "asyncpg.Connection":
     """Helper function to create an asyncpg DB-API connection object.
 
-    :type ip_address: str
-    :param ip_address: A string containing an IP address for the Cloud SQL
-        instance.
+    Args:
+        ip_address (str): The IP address for the Cloud SQL instance.
 
-    :type ctx: ssl.SSLContext
-    :param ctx: An SSLContext object created from the Cloud SQL server CA
-        cert and ephemeral cert.
+        ctx (ssl.SSLContext): An SSL/TLS object created from the Cloud SQL
+            server CA cert and ephemeral cert.
 
-    :type kwargs: Any
-    :param kwargs: Keyword arguments for establishing asyncpg connection
-        object to Cloud SQL instance.
+        server_name (str): The server name of the Cloud SQL instance. Used to
+            verify the server identity for CAS instances.
 
-    :rtype: asyncpg.Connection
-    :returns: An asyncpg.Connection object to a Cloud SQL instance.
+    Returns:
+        (asyncpg.Connection) An asyncpg connection object to the Cloud SQL
+            instance.
     """
     try:
         import asyncpg

--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -144,10 +144,10 @@ class CloudSQLClient:
         # resolve dnsName into IP address for PSC
         # Note that we have to check for PSC enablement also because CAS
         # instances also set the dnsName field.
-        dns_name = ret_dict.get("dnsName", "")
+        # Remove trailing period from DNS name. Required for SSL in Python
+        dns_name = ret_dict.get("dnsName", "").rstrip(".")
         if dns_name and ret_dict.get("pscEnabled"):
-            # Remove trailing period from PSC DNS name. Required for SSL in Python
-            ip_addresses["PSC"] = dns_name.rstrip(".")
+            ip_addresses["PSC"] = dns_name
 
         return {
             "ip_addresses": ip_addresses,

--- a/google/cloud/sql/connector/connection_info.py
+++ b/google/cloud/sql/connector/connection_info.py
@@ -61,8 +61,9 @@ class ConnectionInfo:
             return self.context
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
-        # update ssl.PROTOCOL_TLS_CLIENT default
-        context.check_hostname = False
+        if self.server_ca_mode != "GOOGLE_MANAGED_CAS_CA":
+            # update ssl.PROTOCOL_TLS_CLIENT default
+            context.check_hostname = False
 
         # TODO: remove if/else when Python 3.10 is min version. PEP 644 has been
         # implemented. The ssl module requires OpenSSL 1.1.1 or newer.

--- a/google/cloud/sql/connector/connection_info.py
+++ b/google/cloud/sql/connector/connection_info.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 import ssl
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from aiofiles.tempfile import TemporaryDirectory
 
@@ -39,10 +39,14 @@ class ConnectionInfo:
     server-side Proxy running on a Cloud SQL instance."""
 
     client_cert: str
-    server_ca_cert: str
+    server_ca_cert: List[str]
+    server_ca_mode: str
     private_key: bytes
     ip_addrs: Dict[str, Any]
     database_version: str
+    # The DNSName is from the ConnectSettings API.
+    # It is used to validate the server identity for CAS instances.
+    dns_name: str
     expiration: datetime.datetime
     context: Optional[ssl.SSLContext] = None
 

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -366,6 +366,7 @@ class Connector:
                 return await connector(
                     ip_address,
                     await conn_info.create_ssl_context(enable_iam_auth),
+                    conn_info.dns_name,
                     **kwargs,
                 )
             # synchronous drivers are blocking and run using executor
@@ -373,6 +374,7 @@ class Connector:
                 connector,
                 ip_address,
                 await conn_info.create_ssl_context(enable_iam_auth),
+                conn_info.dns_name,
                 **kwargs,
             )
             return await self._loop.run_in_executor(None, connect_partial)

--- a/google/cloud/sql/connector/pymysql.py
+++ b/google/cloud/sql/connector/pymysql.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import socket
 import ssl
 from typing import Any, TYPE_CHECKING
@@ -24,20 +25,22 @@ if TYPE_CHECKING:
 
 
 def connect(
-    ip_address: str, ctx: ssl.SSLContext, **kwargs: Any
-) -> "pymysql.connections.Connection":
+    ip_address: str, ctx: ssl.SSLContext, server_name: str, **kwargs: Any
+) -> "pymysql.Connection":
     """Helper function to create a pymysql DB-API connection object.
 
-    :type ip_address: str
-    :param ip_address: A string containing an IP address for the Cloud SQL
-        instance.
+    Args:
+        ip_address (str): The IP address for the Cloud SQL instance.
 
-    :type ctx: ssl.SSLContext
-    :param ctx: An SSLContext object created from the Cloud SQL server CA
-        cert and ephemeral cert.
+        ctx (ssl.SSLContext): An SSL/TLS object created from the Cloud SQL
+            server CA cert and ephemeral cert.
 
-    :rtype: pymysql.Connection
-    :returns: A PyMySQL Connection object for the Cloud SQL instance.
+        server_name (str): The server name of the Cloud SQL instance. Used to
+            verify the server identity for CAS instances.
+
+    Returns:
+        (pymysql.Connection) A pymysql connection object to the Cloud SQL
+            instance.
     """
     try:
         import pymysql
@@ -48,11 +51,15 @@ def connect(
 
     # allow automatic IAM database authentication to not require password
     kwargs["password"] = kwargs["password"] if "password" in kwargs else None
-
+    # if CAS instance, check server name
+    if ctx.check_hostname:
+        server_name = server_name
+    else:
+        server_name = None
     # Create socket and wrap with context.
     sock = ctx.wrap_socket(
         socket.create_connection((ip_address, SERVER_PROXY_PORT)),
-        server_hostname=ip_address,
+        server_hostname=server_name,
     )
     # pop timeout as timeout arg is called 'connect_timeout' for pymysql
     timeout = kwargs.pop("timeout")

--- a/google/cloud/sql/connector/utils.py
+++ b/google/cloud/sql/connector/utils.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Tuple
+from typing import List, Tuple
 
 import aiofiles
 from cryptography.hazmat.backends import default_backend
@@ -60,7 +60,7 @@ async def generate_keys() -> Tuple[bytes, str]:
 
 
 async def write_to_file(
-    dir_path: str, serverCaCert: str, ephemeralCert: str, priv_key: bytes
+    dir_path: str, serverCaCert: List[str], ephemeralCert: str, priv_key: bytes
 ) -> Tuple[str, str, str]:
     """
     Helper function to write the serverCaCert, ephemeral certificate and
@@ -71,7 +71,7 @@ async def write_to_file(
     key_filename = f"{dir_path}/priv.pem"
 
     async with aiofiles.open(ca_filename, "w+") as ca_out:
-        await ca_out.write(serverCaCert)
+        await ca_out.write("".join(serverCaCert))
     async with aiofiles.open(cert_filename, "w+") as ephemeral_out:
         await ephemeral_out.write(ephemeralCert)
     async with aiofiles.open(key_filename, "wb") as priv_out:

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -122,3 +122,19 @@ def test_lazy_pg8000_connection() -> None:
         curr_time = time[0]
         assert type(curr_time) is datetime
     connector.close()
+
+
+def test_CAS_pg8000_connection() -> None:
+    """Basic test to get time from database."""
+    inst_conn_name = os.environ["POSTGRES_CAS_CONNECTION_NAME"]
+    user = os.environ["POSTGRES_USER"]
+    password = os.environ["POSTGRES_CAS_PASS"]
+    db = os.environ["POSTGRES_DB"]
+
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db)
+    with engine.connect() as conn:
+        time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
+        conn.commit()
+        curr_time = time[0]
+        assert type(curr_time) is datetime
+    connector.close()

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -111,18 +111,3 @@ def test_lazy_pg8000_iam_authn_connection() -> None:
         curr_time = time[0]
         assert type(curr_time) is datetime
     connector.close()
-
-
-def test_CAS_pg8000_iam_authn_connection() -> None:
-    """Basic test to get time from database."""
-    inst_conn_name = os.environ["POSTGRES_CAS_CONNECTION_NAME"]
-    user = os.environ["POSTGRES_IAM_USER"]
-    db = os.environ["POSTGRES_DB"]
-
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db)
-    with engine.connect() as conn:
-        time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
-        conn.commit()
-        curr_time = time[0]
-        assert type(curr_time) is datetime
-    connector.close()

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -111,3 +111,18 @@ def test_lazy_pg8000_iam_authn_connection() -> None:
         curr_time = time[0]
         assert type(curr_time) is datetime
     connector.close()
+
+
+def test_CAS_pg8000_iam_authn_connection() -> None:
+    """Basic test to get time from database."""
+    inst_conn_name = os.environ["POSTGRES_CAS_CONNECTION_NAME"]
+    user = os.environ["POSTGRES_IAM_USER"]
+    db = os.environ["POSTGRES_DB"]
+
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db)
+    with engine.connect() as conn:
+        time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
+        conn.commit()
+        curr_time = time[0]
+        assert type(curr_time) is datetime
+    connector.close()


### PR DESCRIPTION
The CAS instances will have a different way to verify the server identity (dns name). 

This PR checks the `CA_SERVER_MODE` returned from the ConnectSettings
API and uses DNS name to verify the server identity if a CAS instance. 