### PR TITLE
test: update tests to be more scalable

### DIFF
--- a/tests/system/test_asyncpg_iam_auth.py
+++ b/tests/system/test_asyncpg_iam_auth.py
@@ -13,77 +13,103 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import asyncio
 import os
-from typing import AsyncGenerator
-import uuid
+from typing import Tuple
 
 import asyncpg
-import pytest
 import sqlalchemy
-from sqlalchemy.ext.asyncio import AsyncEngine
-from sqlalchemy.ext.asyncio import create_async_engine
+import sqlalchemy.ext.asyncio
 
 from google.cloud.sql.connector import Connector
 
-table_name = f"books_{uuid.uuid4().hex}"
 
+async def create_sqlalchemy_engine(
+    instance_connection_name: str,
+    user: str,
+    db: str,
+    refresh_strategy: str = "background",
+) -> Tuple[sqlalchemy.ext.asyncio.engine.AsyncEngine, Connector]:
+    """Creates a connection pool for a Cloud SQL instance and returns the pool
+    and the connector. Callers are responsible for closing the pool and the
+    connector.
 
-# The Cloud SQL Python Connector can be used along with SQLAlchemy using the
-# 'async_creator' argument to 'create_async_engine'
-async def init_connection_pool() -> AsyncEngine:
+    A sample invocation looks like:
+
+        engine, connector = await create_sqlalchemy_engine(
+            inst_conn_name,
+            user,
+            db,
+        )
+        async with engine.connect() as conn:
+            time = (await conn.execute(sqlalchemy.text("SELECT NOW()"))).fetchone()
+            curr_time = time[0]
+            # do something with query result
+            await connector.close_async()
+
+    Args:
+        instance_connection_name (str):
+            The instance connection name specifies the instance relative to the
+            project and region. For example: "my-project:my-region:my-instance"
+        user (str):
+            The formatted IAM database username.
+            e.g., my-email@test.com, service-account@project-id.iam
+        db (str):
+            The name of the database, e.g., mydb
+        refresh_strategy (Optional[str]):
+            Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
+            or "background". For serverless environments use "lazy" to avoid
+            errors resulting from CPU being throttled.
+    """
+    loop = asyncio.get_running_loop()
+    connector = Connector(loop=loop, refresh_strategy=refresh_strategy)
+
     async def getconn() -> asyncpg.Connection:
-        loop = asyncio.get_running_loop()
-        # initialize Connector object for connections to Cloud SQL
-        async with Connector(loop=loop) as connector:
-            conn: asyncpg.Connection = await connector.connect_async(
-                os.environ["POSTGRES_IAM_CONNECTION_NAME"],
-                "asyncpg",
-                user=os.environ["POSTGRES_IAM_USER"],
-                db=os.environ["POSTGRES_DB"],
-                enable_iam_auth=True,
-            )
-            return conn
+        conn: asyncpg.Connection = await connector.connect_async(
+            instance_connection_name,
+            "asyncpg",
+            user=user,
+            db=db,
+            ip_type="public",  # can also be "private" or "psc"
+            enable_iam_auth=True,
+        )
+        return conn
 
     # create SQLAlchemy connection pool
-    pool = create_async_engine(
+    engine = sqlalchemy.ext.asyncio.create_async_engine(
         "postgresql+asyncpg://",
         async_creator=getconn,
         execution_options={"isolation_level": "AUTOCOMMIT"},
     )
-    return pool
+    return engine, connector
 
 
-@pytest.fixture(name="pool")
-async def setup() -> AsyncGenerator:
-    pool = await init_connection_pool()
-    async with pool.connect() as conn:
-        await conn.execute(
-            sqlalchemy.text(
-                f"CREATE TABLE IF NOT EXISTS {table_name}"
-                " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
-            )
-        )
+async def test_iam_authn_connection_with_asyncpg() -> None:
+    """Basic test to get time from database."""
+    inst_conn_name = os.environ["POSTGRES_IAM_CONNECTION_NAME"]
+    user = os.environ["POSTGRES_IAM_USER"]
+    db = os.environ["POSTGRES_DB"]
 
-    yield pool
+    pool, connector = await create_sqlalchemy_engine(inst_conn_name, user, db)
 
     async with pool.connect() as conn:
-        await conn.execute(sqlalchemy.text(f"DROP TABLE IF EXISTS {table_name}"))
-    # dispose of asyncpg connection pool
-    await pool.dispose()
+        res = (await conn.execute(sqlalchemy.text("SELECT 1"))).fetchone()
+        assert res[0] == 1
+
+    await connector.close_async()
 
 
-@pytest.mark.asyncio
-async def test_connection_with_asyncpg_iam_auth(pool: AsyncEngine) -> None:
-    insert_stmt = sqlalchemy.text(
-        f"INSERT INTO {table_name} (id, title) VALUES (:id, :title)",
-    )
+async def test_lazy_iam_authn_connection_with_asyncpg() -> None:
+    """Basic test to get time from database."""
+    inst_conn_name = os.environ["POSTGRES_IAM_CONNECTION_NAME"]
+    user = os.environ["POSTGRES_IAM_USER"]
+    db = os.environ["POSTGRES_DB"]
+
+    pool, connector = await create_sqlalchemy_engine(inst_conn_name, user, db, "lazy")
+
     async with pool.connect() as conn:
-        await conn.execute(insert_stmt, parameters={"id": "book1", "title": "Book One"})
-        await conn.execute(insert_stmt, parameters={"id": "book2", "title": "Book Two"})
+        res = (await conn.execute(sqlalchemy.text("SELECT 1"))).fetchone()
+        assert res[0] == 1
 
-        select_stmt = sqlalchemy.text(f"SELECT title FROM {table_name} ORDER BY ID;")
-        rows = (await conn.execute(select_stmt)).fetchall()
-        titles = [row[0] for row in rows]
-
-    assert titles == ["Book One", "Book Two"]
+    await connector.close_async()

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -26,7 +26,7 @@ from google.cloud.sql.connector import Connector
 
 
 def create_sqlalchemy_engine(
-    inst_uri: str,
+    instance_connection_name: str,
     user: str,
     password: str,
     db: str,
@@ -70,7 +70,7 @@ def create_sqlalchemy_engine(
 
     def getconn() -> pg8000.dbapi.Connection:
         conn: pg8000.dbapi.Connection = connector.connect(
-            inst_uri,
+            instance_connection_name,
             "pg8000",
             user=user,
             password=password,

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -39,7 +39,7 @@ def create_sqlalchemy_engine(
     A sample invocation looks like:
 
         engine, connector = create_sqlalchemy_engine(
-            inst_uri,
+            inst_conn_name,
             user,
             password,
             db,

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -1,19 +1,3 @@
-""""
-Copyright 2021 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-  https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
-
 """
 Copyright 2021 Google LLC
 
@@ -69,9 +53,8 @@ def create_sqlalchemy_engine(
             The instance connection name specifies the instance relative to the
             project and region. For example: "my-project:my-region:my-instance"
         user (str):
-            The database user name, e.g., postgres
-        password (str):
-            The database user's password, e.g., secret-password
+            The formatted IAM database username.
+            e.g., my-email@test.com, service-account@project-id.iam
         db (str):
             The name of the database, e.g., mydb
         refresh_strategy (Optional[str]):

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -14,73 +14,117 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+"""
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from datetime import datetime
 import os
-from typing import Generator
+from typing import Tuple
 
 import pg8000
-import pytest
 import sqlalchemy
 
 from google.cloud.sql.connector import Connector
 
 
-# The Cloud SQL Python Connector can be used along with SQLAlchemy using the
-# 'creator' argument to 'create_engine'
-def init_connection_engine(connector: Connector) -> sqlalchemy.engine.Engine:
-    # initialize Connector object for connections to Cloud SQL
+def create_sqlalchemy_engine(
+    instance_connection_name: str,
+    user: str,
+    db: str,
+    refresh_strategy: str = "background",
+) -> Tuple[sqlalchemy.engine.Engine, Connector]:
+    """Creates a connection pool for a Cloud SQL instance and returns the pool
+    and the connector. Callers are responsible for closing the pool and the
+    connector.
+
+    A sample invocation looks like:
+
+        engine, connector = create_sqlalchemy_engine(
+            instance_connection_name,
+            user,
+            db,
+        )
+        with engine.connect() as conn:
+            time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
+            conn.commit()
+            curr_time = time[0]
+            # do something with query result
+            connector.close()
+
+    Args:
+        instance_connection_name (str):
+            The instance connection name specifies the instance relative to the
+            project and region. For example: "my-project:my-region:my-instance"
+        user (str):
+            The database user name, e.g., postgres
+        password (str):
+            The database user's password, e.g., secret-password
+        db (str):
+            The name of the database, e.g., mydb
+        refresh_strategy (Optional[str]):
+            Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
+            or "background". For serverless environments use "lazy" to avoid
+            errors resulting from CPU being throttled.
+    """
+    connector = Connector(refresh_strategy=refresh_strategy)
+
     def getconn() -> pg8000.dbapi.Connection:
         conn: pg8000.dbapi.Connection = connector.connect(
-            os.environ["POSTGRES_IAM_CONNECTION_NAME"],
+            instance_connection_name,
             "pg8000",
-            user=os.environ["POSTGRES_IAM_USER"],
-            db=os.environ["POSTGRES_DB"],
+            user=user,
+            db=db,
+            ip_type="public",  # can also be "private" or "psc"
             enable_iam_auth=True,
         )
         return conn
 
     # create SQLAlchemy connection pool
-    pool = sqlalchemy.create_engine(
+    engine = sqlalchemy.create_engine(
         "postgresql+pg8000://",
         creator=getconn,
-        execution_options={"isolation_level": "AUTOCOMMIT"},
     )
-    pool.dialect.description_encoding = None
-    return pool
+    return engine, connector
 
 
-@pytest.fixture
-def pool() -> Generator:
-    connector = Connector()
-    pool = init_connection_engine(connector)
+def test_pg8000_iam_authn_connection() -> None:
+    """Basic test to get time from database."""
+    inst_conn_name = os.environ["POSTGRES_IAM_CONNECTION_NAME"]
+    user = os.environ["POSTGRES_IAM_USER"]
+    db = os.environ["POSTGRES_DB"]
 
-    yield pool
-
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db)
+    with engine.connect() as conn:
+        time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
+        conn.commit()
+        curr_time = time[0]
+        assert type(curr_time) is datetime
     connector.close()
 
 
-@pytest.fixture
-def lazy_pool() -> Generator:
-    connector = Connector(refresh_strategy="lazy")
-    pool = init_connection_engine(connector)
+def test_lazy_pg8000_iam_authn_connection() -> None:
+    """Basic test to get time from database."""
+    inst_conn_name = os.environ["POSTGRES_IAM_CONNECTION_NAME"]
+    user = os.environ["POSTGRES_IAM_USER"]
+    db = os.environ["POSTGRES_DB"]
 
-    yield pool
-
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, "lazy")
+    with engine.connect() as conn:
+        time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
+        conn.commit()
+        curr_time = time[0]
+        assert type(curr_time) is datetime
     connector.close()
-
-
-def test_pooled_connection_with_pg8000_iam_auth(
-    pool: sqlalchemy.engine.Engine,
-) -> None:
-    with pool.connect() as conn:
-        result = conn.execute(sqlalchemy.text("SELECT 1;")).fetchone()
-        assert isinstance(result[0], int)
-        assert result[0] == 1
-
-
-def test_lazy_connection_with_pg8000_iam_auth(
-    lazy_pool: sqlalchemy.engine.Engine,
-) -> None:
-    with lazy_pool.connect() as conn:
-        result = conn.execute(sqlalchemy.text("SELECT 1;")).fetchone()
-        assert isinstance(result[0], int)
-        assert result[0] == 1

--- a/tests/system/test_pymysql_connection.py
+++ b/tests/system/test_pymysql_connection.py
@@ -13,80 +13,112 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
+from datetime import datetime
 import os
-from typing import Generator
-import uuid
+from typing import Tuple
 
 # [START cloud_sql_connector_mysql_pymysql]
 import pymysql
-import pytest
 import sqlalchemy
 
 from google.cloud.sql.connector import Connector
 
-# [END cloud_sql_connector_mysql_pymysql]
 
-table_name = f"books_{uuid.uuid4().hex}"
+def create_sqlalchemy_engine(
+    instance_connection_name: str,
+    user: str,
+    password: str,
+    db: str,
+    refresh_strategy: str = "background",
+) -> Tuple[sqlalchemy.engine.Engine, Connector]:
+    """Creates a connection pool for a Cloud SQL instance and returns the pool
+    and the connector. Callers are responsible for closing the pool and the
+    connector.
 
+    A sample invocation looks like:
 
-# [START cloud_sql_connector_mysql_pymysql]
-# The Cloud SQL Python Connector can be used along with SQLAlchemy using the
-# 'creator' argument to 'create_engine'
-def init_connection_engine() -> sqlalchemy.engine.Engine:
-    def getconn() -> pymysql.connections.Connection:
-        # initialize Connector object for connections to Cloud SQL
-        with Connector() as connector:
-            conn: pymysql.connections.Connection = connector.connect(
-                os.environ["MYSQL_CONNECTION_NAME"],
-                "pymysql",
-                user=os.environ["MYSQL_USER"],
-                password=os.environ["MYSQL_PASS"],
-                db=os.environ["MYSQL_DB"],
-                ip_type="public",  # can also be "private" or "psc"
-            )
-            return conn
+        engine, connector = create_sqlalchemy_engine(
+            inst_conn_name,
+            user,
+            password,
+            db,
+        )
+        with engine.connect() as conn:
+            time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
+            conn.commit()
+            curr_time = time[0]
+            # do something with query result
+            connector.close()
+
+    Args:
+        instance_connection_name (str):
+            The instance connection name specifies the instance relative to the
+            project and region. For example: "my-project:my-region:my-instance"
+        user (str):
+            The database user name, e.g., root
+        password (str):
+            The database user's password, e.g., secret-password
+        db (str):
+            The name of the database, e.g., mydb
+        refresh_strategy (Optional[str]):
+            Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
+            or "background". For serverless environments use "lazy" to avoid
+            errors resulting from CPU being throttled.
+    """
+    connector = Connector(refresh_strategy=refresh_strategy)
+
+    def getconn() -> pymysql.Connection:
+        conn: pymysql.Connection = connector.connect(
+            instance_connection_name,
+            "pymysql",
+            user=user,
+            password=password,
+            db=db,
+            ip_type="public",  # can also be "private" or "psc"
+        )
+        return conn
 
     # create SQLAlchemy connection pool
-    pool = sqlalchemy.create_engine(
+    engine = sqlalchemy.create_engine(
         "mysql+pymysql://",
         creator=getconn,
-        execution_options={"isolation_level": "AUTOCOMMIT"},
     )
-    return pool
+    return engine, connector
 
 
 # [END cloud_sql_connector_mysql_pymysql]
 
 
-@pytest.fixture(name="pool")
-def setup() -> Generator:
-    pool = init_connection_engine()
+def test_pymysql_connection() -> None:
+    """Basic test to get time from database."""
+    inst_conn_name = os.environ["MYSQL_CONNECTION_NAME"]
+    user = os.environ["MYSQL_USER"]
+    password = os.environ["MYSQL_PASS"]
+    db = os.environ["MYSQL_DB"]
 
-    with pool.connect() as conn:
-        conn.execute(
-            sqlalchemy.text(
-                f"CREATE TABLE IF NOT EXISTS `{table_name}`"
-                " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
-            )
-        )
-
-    yield pool
-
-    with pool.connect() as conn:
-        conn.execute(sqlalchemy.text(f"DROP TABLE IF EXISTS `{table_name}`"))
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db)
+    with engine.connect() as conn:
+        time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
+        conn.commit()
+        curr_time = time[0]
+        assert type(curr_time) is datetime
+    connector.close()
 
 
-def test_pooled_connection_with_pymysql(pool: sqlalchemy.engine.Engine) -> None:
-    insert_stmt = sqlalchemy.text(
-        f"INSERT INTO {table_name} (id, title) VALUES (:id, :title)",
+def test_lazy_pymysql_connection() -> None:
+    """Basic test to get time from database."""
+    inst_conn_name = os.environ["MYSQL_CONNECTION_NAME"]
+    user = os.environ["MYSQL_USER"]
+    password = os.environ["MYSQL_PASS"]
+    db = os.environ["MYSQL_DB"]
+
+    engine, connector = create_sqlalchemy_engine(
+        inst_conn_name, user, password, db, "lazy"
     )
-    with pool.connect() as conn:
-        conn.execute(insert_stmt, parameters={"id": "book1", "title": "Book One"})
-        conn.execute(insert_stmt, parameters={"id": "book2", "title": "Book Two"})
-
-    select_stmt = sqlalchemy.text(f"SELECT title FROM {table_name} ORDER BY ID;")
-    with pool.connect() as conn:
-        rows = conn.execute(select_stmt).fetchall()
-        titles = [row[0] for row in rows]
-
-    assert titles == ["Book One", "Book Two"]
+    with engine.connect() as conn:
+        time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
+        conn.commit()
+        curr_time = time[0]
+        assert type(curr_time) is datetime
+    connector.close()

--- a/tests/system/test_pymysql_iam_auth.py
+++ b/tests/system/test_pymysql_iam_auth.py
@@ -71,6 +71,7 @@ def create_sqlalchemy_engine(
             user=user,
             db=db,
             ip_type="public",  # can also be "private" or "psc"
+            enable_iam_auth=True,
         )
         return conn
 

--- a/tests/system/test_pytds_connection.py
+++ b/tests/system/test_pytds_connection.py
@@ -13,84 +13,108 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import os
-from typing import Generator
-import uuid
+from typing import Tuple
 
 # [START cloud_sql_connector_mysql_pytds]
 import pytds
-import pytest
 import sqlalchemy
 
 from google.cloud.sql.connector import Connector
 
-# [END cloud_sql_connector_mysql_pytds]
 
-table_name = f"books_{uuid.uuid4().hex}"
+def create_sqlalchemy_engine(
+    instance_connection_name: str,
+    user: str,
+    password: str,
+    db: str,
+    refresh_strategy: str = "background",
+) -> Tuple[sqlalchemy.engine.Engine, Connector]:
+    """Creates a connection pool for a Cloud SQL instance and returns the pool
+    and the connector. Callers are responsible for closing the pool and the
+    connector.
 
+    A sample invocation looks like:
 
-# [START cloud_sql_connector_mysql_pytds]
-# The Cloud SQL Python Connector can be used along with SQLAlchemy using the
-# 'creator' argument to 'create_engine'. To use SQLAlchemy with pytds, include
-# 'sqlalchemy-pytds` in your dependencies
-def init_connection_engine() -> sqlalchemy.engine.Engine:
+        engine, connector = create_sqlalchemy_engine(
+            inst_conn_name,
+            user,
+            password,
+            db,
+        )
+        with engine.connect() as conn:
+            data = conn.execute(sqlalchemy.text("SELECT 1")).fetchone()
+            conn.commit()
+            # do something with query result
+            connector.close()
+
+    Args:
+        instance_connection_name (str):
+            The instance connection name specifies the instance relative to the
+            project and region. For example: "my-project:my-region:my-instance"
+        user (str):
+            The database user name, e.g., sqlserver
+        password (str):
+            The database user's password, e.g., secret-password
+        db (str):
+            The name of the database, e.g., mydb
+        refresh_strategy (Optional[str]):
+            Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
+            or "background". For serverless environments use "lazy" to avoid
+            errors resulting from CPU being throttled.
+    """
+    connector = Connector(refresh_strategy=refresh_strategy)
+
     def getconn() -> pytds.Connection:
-        # initialize Connector object for connections to Cloud SQL
-        with Connector() as connector:
-            conn = connector.connect(
-                os.environ["SQLSERVER_CONNECTION_NAME"],
-                "pytds",
-                user=os.environ["SQLSERVER_USER"],
-                password=os.environ["SQLSERVER_PASS"],
-                db=os.environ["SQLSERVER_DB"],
-                ip_type="public",  # can also be "private" or "psc"
-            )
-            return conn
+        conn: pytds.Connection = connector.connect(
+            instance_connection_name,
+            "pytds",
+            user=user,
+            password=password,
+            db=db,
+            ip_type="public",  # can also be "private" or "psc"
+        )
+        return conn
 
     # create SQLAlchemy connection pool
-    pool = sqlalchemy.create_engine(
+    engine = sqlalchemy.create_engine(
         "mssql+pytds://",
         creator=getconn,
     )
-    pool.dialect.description_encoding = None
-    return pool
+    return engine, connector
 
 
 # [END cloud_sql_connector_mysql_pytds]
 
 
-@pytest.fixture(name="pool")
-def setup() -> Generator:
-    pool = init_connection_engine()
+def test_pytds_connection() -> None:
+    """Basic test to get time from database."""
+    inst_conn_name = os.environ["SQLSERVER_CONNECTION_NAME"]
+    user = os.environ["SQLSERVER_USER"]
+    password = os.environ["SQLSERVER_PASS"]
+    db = os.environ["SQLSERVER_DB"]
 
-    with pool.connect() as conn:
-        conn.execute(
-            sqlalchemy.text(
-                f"CREATE TABLE {table_name}"
-                " ( id CHAR(20) NOT NULL, title TEXT NOT NULL );"
-            )
-        )
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db)
+    with engine.connect() as conn:
+        res = conn.execute(sqlalchemy.text("SELECT 1")).fetchone()
         conn.commit()
-
-    yield pool
-
-    with pool.connect() as conn:
-        conn.execute(sqlalchemy.text(f"DROP TABLE {table_name}"))
-        conn.commit()
+        assert res[0] == 1
+    connector.close()
 
 
-def test_pooled_connection_with_pytds(pool: sqlalchemy.engine.Engine) -> None:
-    insert_stmt = sqlalchemy.text(
-        f"INSERT INTO {table_name} (id, title) VALUES (:id, :title)",
+def test_lazy_pytds_connection() -> None:
+    """Basic test to get time from database."""
+    inst_conn_name = os.environ["SQLSERVER_CONNECTION_NAME"]
+    user = os.environ["SQLSERVER_USER"]
+    password = os.environ["SQLSERVER_PASS"]
+    db = os.environ["SQLSERVER_DB"]
+
+    engine, connector = create_sqlalchemy_engine(
+        inst_conn_name, user, password, db, "lazy"
     )
-    with pool.connect() as conn:
-        conn.execute(insert_stmt, parameters={"id": "book1", "title": "Book One"})
-        conn.execute(insert_stmt, parameters={"id": "book2", "title": "Book Two"})
+    with engine.connect() as conn:
+        res = conn.execute(sqlalchemy.text("SELECT 1")).fetchone()
         conn.commit()
-
-    select_stmt = sqlalchemy.text(f"SELECT title FROM {table_name} ORDER BY ID;")
-    with pool.connect() as conn:
-        rows = conn.execute(select_stmt).fetchall()
-        titles = [row[0] for row in rows]
-
-    assert titles == ["Book One", "Book Two"]
+        assert res[0] == 1
+    connector.close()


### PR DESCRIPTION
Current integration tests use a bad practice of initializing the `Connector`
within the `getconn` creator func. This creates a `Connector` on each
database conn instead of re-using a single connector:

```python
def getconn() -> pg8000.dbapi.Connection:
    # initialize Connector object for connections to Cloud SQL
    with Connector() as connector:
```

This PR also makes a single test file be able to have tests connect to
different Cloud SQL instances (wanted for CAS tests) by removing
the pytest fixture in place of helper func.