### PR TITLE
refactor: allow cert chain for server cert

### DIFF
--- a/google/cloud/sql/connector/connection_info.py
+++ b/google/cloud/sql/connector/connection_info.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 import ssl
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from aiofiles.tempfile import TemporaryDirectory
 
@@ -39,7 +39,7 @@ class ConnectionInfo:
     server-side Proxy running on a Cloud SQL instance."""
 
     client_cert: str
-    server_ca_cert: str
+    server_ca_cert: List[str]
     private_key: bytes
     ip_addrs: Dict[str, Any]
     database_version: str

--- a/google/cloud/sql/connector/utils.py
+++ b/google/cloud/sql/connector/utils.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Tuple
+from typing import List, Tuple
 
 import aiofiles
 from cryptography.hazmat.backends import default_backend
@@ -60,7 +60,7 @@ async def generate_keys() -> Tuple[bytes, str]:
 
 
 async def write_to_file(
-    dir_path: str, serverCaCert: str, ephemeralCert: str, priv_key: bytes
+    dir_path: str, serverCaCert: List[str], ephemeralCert: str, priv_key: bytes
 ) -> Tuple[str, str, str]:
     """
     Helper function to write the serverCaCert, ephemeral certificate and
@@ -71,7 +71,7 @@ async def write_to_file(
     key_filename = f"{dir_path}/priv.pem"
 
     async with aiofiles.open(ca_filename, "w+") as ca_out:
-        await ca_out.write(serverCaCert)
+        await ca_out.write("".join(serverCaCert))
     async with aiofiles.open(cert_filename, "w+") as ephemeral_out:
         await ephemeral_out.write(ephemeralCert)
     async with aiofiles.open(key_filename, "wb") as priv_out:


### PR DESCRIPTION
CAS-based CA instances can have a chain of trust.

Should allow server CA to be a list of certs to allow this cert chain.

This was part of #1154 that was closed.