### PR TITLE
feat: add support for Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.13"]
       fail-fast: false
     permissions:
       contents: read
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.13"]
       fail-fast: false
     permissions:
       contents: read

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,7 +25,7 @@ ISORT_VERSION = "isort==5.13.2"
 
 LINT_PATHS = ["google", "tests", "noxfile.py", "setup.py"]
 
-TEST_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12"]
+TEST_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 
 @nox.session

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     platforms="Posix; MacOS X; Windows",
     packages=packages,


### PR DESCRIPTION
Python 3.13 is now a stable release and GA.

Add it to supported versions in `setup.py` and test suite.

[Released on October 7, 2024](https://www.python.org/downloads/release/python-3130/)

Closes #1178 