### PR TITLE
chore: update type hints to standard collections

### DIFF
--- a/google/cloud/sql/connector/asyncpg.py
+++ b/google/cloud/sql/connector/asyncpg.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import ssl
 from typing import Any, TYPE_CHECKING
 

--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
-from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 
 import aiohttp
 from cryptography.hazmat.backends import default_backend
@@ -98,7 +98,7 @@ class CloudSQLClient:
         project: str,
         region: str,
         instance: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Requests metadata from the Cloud SQL Instance
         and returns a dictionary containing the IP addresses and certificate
         authority of the Cloud SQL Instance.
@@ -113,7 +113,7 @@ class CloudSQLClient:
         :type instance: str
         :param instance: A string representing the name of the instance.
 
-        :rtype: Dict[str: Union[Dict, str]]
+        :rtype: dict[str: Union[dict, str]]
         :returns: Returns a dictionary containing a dictionary of all IP
             addresses and their type and a string representing the
             certificate authority.
@@ -161,7 +161,7 @@ class CloudSQLClient:
         instance: str,
         pub_key: str,
         enable_iam_auth: bool = False,
-    ) -> Tuple[str, datetime.datetime]:
+    ) -> tuple[str, datetime.datetime]:
         """Asynchronously requests an ephemeral certificate from the Cloud SQL Instance.
 
         :type project: str

--- a/google/cloud/sql/connector/connection_info.py
+++ b/google/cloud/sql/connector/connection_info.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 import ssl
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 
 from aiofiles.tempfile import TemporaryDirectory
 
@@ -41,7 +41,7 @@ class ConnectionInfo:
     client_cert: str
     server_ca_cert: str
     private_key: bytes
-    ip_addrs: Dict[str, Any]
+    ip_addrs: dict[str, Any]
     database_version: str
     expiration: datetime.datetime
     context: Optional[ssl.SSLContext] = None

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -21,7 +21,7 @@ from functools import partial
 import logging
 from threading import Thread
 from types import TracebackType
-from typing import Any, Dict, Optional, Tuple, Type, Union
+from typing import Any, Optional, Type, Union
 
 import google.auth
 from google.auth.credentials import Credentials
@@ -133,8 +133,8 @@ class Connector:
                 )
         # initialize dict to store caches, key is a tuple consisting of instance
         # connection name string and enable_iam_auth boolean flag
-        self._cache: Dict[
-            Tuple[str, bool], Union[RefreshAheadCache, LazyRefreshCache]
+        self._cache: dict[
+            tuple[str, bool], Union[RefreshAheadCache, LazyRefreshCache]
         ] = {}
         self._client: Optional[CloudSQLClient] = None
 

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -22,7 +22,6 @@ from datetime import timedelta
 from datetime import timezone
 import logging
 import re
-from typing import Tuple
 
 import aiohttp
 
@@ -43,7 +42,7 @@ APPLICATION_NAME = "cloud-sql-python-connector"
 CONN_NAME_REGEX = re.compile(("([^:]+(:[^:]+)?):([^:]+):([^:]+)"))
 
 
-def _parse_instance_connection_name(connection_name: str) -> Tuple[str, str, str]:
+def _parse_instance_connection_name(connection_name: str) -> tuple[str, str, str]:
     if CONN_NAME_REGEX.fullmatch(connection_name) is None:
         raise ValueError(
             "Arg `instance_connection_string` must have "

--- a/google/cloud/sql/connector/refresh_utils.py
+++ b/google/cloud/sql/connector/refresh_utils.py
@@ -21,7 +21,7 @@ import copy
 import datetime
 import logging
 import random
-from typing import Any, Callable, List
+from typing import Any, Callable
 
 import aiohttp
 from google.auth.credentials import Credentials
@@ -77,7 +77,7 @@ async def _is_valid(task: asyncio.Task) -> bool:
 
 def _downscope_credentials(
     credentials: Credentials,
-    scopes: List[str] = ["https://www.googleapis.com/auth/sqlservice.login"],
+    scopes: list[str] = ["https://www.googleapis.com/auth/sqlservice.login"],
 ) -> Credentials:
     """Generate a down-scoped credential.
 
@@ -85,7 +85,7 @@ def _downscope_credentials(
     :param credentials
         Credentials object used to generate down-scoped credentials.
 
-    :type scopes: List[str]
+    :type scopes: list[str]
     :param scopes
         List of Google scopes to include in down-scoped credentials object.
 

--- a/google/cloud/sql/connector/utils.py
+++ b/google/cloud/sql/connector/utils.py
@@ -14,15 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Tuple
-
 import aiofiles
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 
-async def generate_keys() -> Tuple[bytes, str]:
+async def generate_keys() -> tuple[bytes, str]:
     """A helper function to generate the private and public keys.
 
     backend - The value specified is default_backend(). This is because the
@@ -61,7 +59,7 @@ async def generate_keys() -> Tuple[bytes, str]:
 
 async def write_to_file(
     dir_path: str, serverCaCert: str, ephemeralCert: str, priv_key: bytes
-) -> Tuple[str, str, str]:
+) -> tuple[str, str, str]:
     """
     Helper function to write the serverCaCert, ephemeral certificate and
     private key to .pem files in a given directory

--- a/tests/system/test_asyncpg_connection.py
+++ b/tests/system/test_asyncpg_connection.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 import asyncio
 import os
-from typing import Tuple
 
 import asyncpg
 import sqlalchemy
@@ -31,7 +30,7 @@ async def create_sqlalchemy_engine(
     password: str,
     db: str,
     refresh_strategy: str = "background",
-) -> Tuple[sqlalchemy.ext.asyncio.engine.AsyncEngine, Connector]:
+) -> tuple[sqlalchemy.ext.asyncio.engine.AsyncEngine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
     and the connector. Callers are responsible for closing the pool and the
     connector.

--- a/tests/system/test_asyncpg_iam_auth.py
+++ b/tests/system/test_asyncpg_iam_auth.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 import asyncio
 import os
-from typing import Tuple
 
 import asyncpg
 import sqlalchemy
@@ -30,7 +29,7 @@ async def create_sqlalchemy_engine(
     user: str,
     db: str,
     refresh_strategy: str = "background",
-) -> Tuple[sqlalchemy.ext.asyncio.engine.AsyncEngine, Connector]:
+) -> tuple[sqlalchemy.ext.asyncio.engine.AsyncEngine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
     and the connector. Callers are responsible for closing the pool and the
     connector.

--- a/tests/system/test_ip_types.py
+++ b/tests/system/test_ip_types.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import os
 import uuid
 

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 from datetime import datetime
 import os
-from typing import Tuple
 
 # [START cloud_sql_connector_postgres_pg8000]
 import pg8000
@@ -31,7 +30,7 @@ def create_sqlalchemy_engine(
     password: str,
     db: str,
     refresh_strategy: str = "background",
-) -> Tuple[sqlalchemy.engine.Engine, Connector]:
+) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
     and the connector. Callers are responsible for closing the pool and the
     connector.

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 from datetime import datetime
 import os
-from typing import Tuple
 
 import pg8000
 import sqlalchemy
@@ -29,7 +28,7 @@ def create_sqlalchemy_engine(
     user: str,
     db: str,
     refresh_strategy: str = "background",
-) -> Tuple[sqlalchemy.engine.Engine, Connector]:
+) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
     and the connector. Callers are responsible for closing the pool and the
     connector.

--- a/tests/system/test_pymysql_connection.py
+++ b/tests/system/test_pymysql_connection.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 from datetime import datetime
 import os
-from typing import Tuple
 
 # [START cloud_sql_connector_mysql_pymysql]
 import pymysql
@@ -31,7 +30,7 @@ def create_sqlalchemy_engine(
     password: str,
     db: str,
     refresh_strategy: str = "background",
-) -> Tuple[sqlalchemy.engine.Engine, Connector]:
+) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
     and the connector. Callers are responsible for closing the pool and the
     connector.

--- a/tests/system/test_pymysql_iam_auth.py
+++ b/tests/system/test_pymysql_iam_auth.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 from datetime import datetime
 import os
-from typing import Tuple
 
 import pymysql
 import sqlalchemy
@@ -29,7 +28,7 @@ def create_sqlalchemy_engine(
     user: str,
     db: str,
     refresh_strategy: str = "background",
-) -> Tuple[sqlalchemy.engine.Engine, Connector]:
+) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
     and the connector. Callers are responsible for closing the pool and the
     connector.

--- a/tests/system/test_pytds_connection.py
+++ b/tests/system/test_pytds_connection.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 import os
-from typing import Tuple
 
 # [START cloud_sql_connector_mysql_pytds]
 import pytds
@@ -30,7 +29,7 @@ def create_sqlalchemy_engine(
     password: str,
     db: str,
     refresh_strategy: str = "background",
-) -> Tuple[sqlalchemy.engine.Engine, Connector]:
+) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
     and the connector. Callers are responsible for closing the pool and the
     connector.

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -19,7 +19,7 @@ limitations under the License.
 import datetime
 import json
 import ssl
-from typing import Any, Callable, Dict, Literal, Optional, Tuple
+from typing import Any, Callable, Literal, Optional
 
 from aiofiles.tempfile import TemporaryDirectory
 from aiohttp import web
@@ -113,7 +113,7 @@ def generate_cert(
     cert_before: datetime.datetime = datetime.datetime.now(datetime.timezone.utc),
     cert_after: datetime.datetime = datetime.datetime.now(datetime.timezone.utc)
     + datetime.timedelta(hours=1),
-) -> Tuple[x509.CertificateBuilder, rsa.RSAPrivateKey]:
+) -> tuple[x509.CertificateBuilder, rsa.RSAPrivateKey]:
     """
     Generate a private key and cert object to be used in testing.
     """
@@ -221,7 +221,7 @@ class FakeCSQLInstance:
         region: str = "test-region",
         name: str = "test-instance",
         db_version: str = "POSTGRES_15",
-        ip_addrs: Dict = {
+        ip_addrs: dict = {
             "PRIMARY": "127.0.0.1",
             "PRIVATE": "10.0.0.1",
         },

--- a/tests/unit/test_asyncpg.py
+++ b/tests/unit/test_asyncpg.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import ssl
 from typing import Any
 


### PR DESCRIPTION
Updates type hints to use standard collections (`list`, `tuple`, `dict`). 
We can do this now that Python 3.8 was removed

As of Python 3.9 and [PEP 585](https://peps.python.org/pep-0585/) standard collections can be subscripted in
favor of their `typing` counterparts which are now deprecated.