### PR TITLE
refactor: add `ConnectionName` class

### DIFF
--- a/google/cloud/sql/connector/connection_name.py
+++ b/google/cloud/sql/connector/connection_name.py
@@ -1,0 +1,51 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+import re
+
+# Instance connection name is the format <PROJECT>:<REGION>:<INSTANCE_NAME>
+# Additionally, we have to support legacy "domain-scoped" projects
+# (e.g. "google.com:PROJECT")
+CONN_NAME_REGEX = re.compile(("([^:]+(:[^:]+)?):([^:]+):([^:]+)"))
+
+
+@dataclass
+class ConnectionName:
+    """ConnectionName represents a Cloud SQL instance's "instance connection name".
+
+    Takes the format "<PROJECT>:<REGION>:<INSTANCE_NAME>".
+    """
+
+    project: str
+    region: str
+    instance_name: str
+
+    def __str__(self):
+        return f"{self.project}:{self.region}:{self.instance_name}"
+
+
+def _parse_instance_connection_name(connection_name: str) -> ConnectionName:
+    if CONN_NAME_REGEX.fullmatch(connection_name) is None:
+        raise ValueError(
+            "Arg `instance_connection_string` must have "
+            "format: PROJECT:REGION:INSTANCE, "
+            f"got {connection_name}."
+        )
+    connection_name_split = CONN_NAME_REGEX.split(connection_name)
+    return ConnectionName(
+        connection_name_split[1],
+        connection_name_split[3],
+        connection_name_split[4],
+    )

--- a/google/cloud/sql/connector/connection_name.py
+++ b/google/cloud/sql/connector/connection_name.py
@@ -32,7 +32,7 @@ class ConnectionName:
     region: str
     instance_name: str
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.project}:{self.region}:{self.instance_name}"
 
 

--- a/google/cloud/sql/connector/lazy.py
+++ b/google/cloud/sql/connector/lazy.py
@@ -21,7 +21,7 @@ from typing import Optional
 
 from google.cloud.sql.connector.client import CloudSQLClient
 from google.cloud.sql.connector.connection_info import ConnectionInfo
-from google.cloud.sql.connector.instance import _parse_instance_connection_name
+from google.cloud.sql.connector.connection_name import _parse_instance_connection_name
 from google.cloud.sql.connector.refresh_utils import _refresh_buffer
 
 logger = logging.getLogger(name=__name__)
@@ -56,10 +56,13 @@ class LazyRefreshCache:
                 connections.
         """
         # validate and parse instance connection name
-        self._project, self._region, self._instance = _parse_instance_connection_name(
-            instance_connection_string
+        conn_name = _parse_instance_connection_name(instance_connection_string)
+        self._project, self._region, self._instance = (
+            conn_name.project,
+            conn_name.region,
+            conn_name.instance_name,
         )
-        self._instance_connection_string = instance_connection_string
+        self._conn_name = conn_name
 
         self._enable_iam_auth = enable_iam_auth
         self._keys = keys
@@ -91,12 +94,12 @@ class LazyRefreshCache:
                 < (self._cached.expiration - timedelta(seconds=_refresh_buffer))
             ):
                 logger.debug(
-                    f"['{self._instance_connection_string}']: Connection info "
+                    f"['{str(self._conn_name)}']: Connection info "
                     "is still valid, using cached info"
                 )
                 return self._cached
             logger.debug(
-                f"['{self._instance_connection_string}']: Connection info "
+                f"['{str(self._conn_name)}']: Connection info "
                 "refresh operation started"
             )
             try:
@@ -109,16 +112,16 @@ class LazyRefreshCache:
                 )
             except Exception as e:
                 logger.debug(
-                    f"['{self._instance_connection_string}']: Connection info "
+                    f"['{str(self._conn_name)}']: Connection info "
                     f"refresh operation failed: {str(e)}"
                 )
                 raise
             logger.debug(
-                f"['{self._instance_connection_string}']: Connection info "
+                f"['{str(self._conn_name)}']: Connection info "
                 "refresh operation completed successfully"
             )
             logger.debug(
-                f"['{self._instance_connection_string}']: Current certificate "
+                f"['{str(self._conn_name)}']: Current certificate "
                 f"expiration = {str(conn_info.expiration)}"
             )
             self._cached = conn_info

--- a/google/cloud/sql/connector/lazy.py
+++ b/google/cloud/sql/connector/lazy.py
@@ -94,13 +94,12 @@ class LazyRefreshCache:
                 < (self._cached.expiration - timedelta(seconds=_refresh_buffer))
             ):
                 logger.debug(
-                    f"['{str(self._conn_name)}']: Connection info "
+                    f"['{self._conn_name}']: Connection info "
                     "is still valid, using cached info"
                 )
                 return self._cached
             logger.debug(
-                f"['{str(self._conn_name)}']: Connection info "
-                "refresh operation started"
+                f"['{self._conn_name}']: Connection info " "refresh operation started"
             )
             try:
                 conn_info = await self._client.get_connection_info(
@@ -112,16 +111,16 @@ class LazyRefreshCache:
                 )
             except Exception as e:
                 logger.debug(
-                    f"['{str(self._conn_name)}']: Connection info "
+                    f"['{self._conn_name}']: Connection info "
                     f"refresh operation failed: {str(e)}"
                 )
                 raise
             logger.debug(
-                f"['{str(self._conn_name)}']: Connection info "
+                f"['{self._conn_name}']: Connection info "
                 "refresh operation completed successfully"
             )
             logger.debug(
-                f"['{str(self._conn_name)}']: Current certificate "
+                f"['{self._conn_name}']: Current certificate "
                 f"expiration = {str(conn_info.expiration)}"
             )
             self._cached = conn_info

--- a/google/cloud/sql/connector/pg8000.py
+++ b/google/cloud/sql/connector/pg8000.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import socket
 import ssl
 from typing import Any, TYPE_CHECKING

--- a/google/cloud/sql/connector/pymysql.py
+++ b/google/cloud/sql/connector/pymysql.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import socket
 import ssl
 from typing import Any, TYPE_CHECKING

--- a/google/cloud/sql/connector/pytds.py
+++ b/google/cloud/sql/connector/pytds.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import platform
 import socket
 import ssl

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,6 +51,7 @@ def lint(session):
         "--check-only",
         "--diff",
         "--profile=google",
+        "-w=88",
         *LINT_PATHS,
     )
     session.run("black", "--check", "--diff", *LINT_PATHS)
@@ -85,6 +86,7 @@ def format(session):
         "isort",
         "--fss",
         "--profile=google",
+        "-w=88",
         *LINT_PATHS,
     )
     session.run(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import asyncio
 import os
 import socket

--- a/tests/unit/test_connection_name.py
+++ b/tests/unit/test_connection_name.py
@@ -1,0 +1,56 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest  # noqa F401 Needed to run the tests
+
+from google.cloud.sql.connector.connection_name import _parse_instance_connection_name
+from google.cloud.sql.connector.connection_name import ConnectionName
+
+
+def test_ConnectionName() -> None:
+    conn_name = ConnectionName("project", "region", "instance")
+    # test class attributes are set properly
+    assert conn_name.project == "project"
+    assert conn_name.region == "region"
+    assert conn_name.instance_name == "instance"
+    # test ConnectionName str() method prints instance connection name
+    assert str(conn_name) == "project:region:instance"
+
+
+@pytest.mark.parametrize(
+    "connection_name, expected",
+    [
+        ("project:region:instance", ConnectionName("project", "region", "instance")),
+        (
+            "domain-prefix:project:region:instance",
+            ConnectionName("domain-prefix:project", "region", "instance"),
+        ),
+    ],
+)
+def test_parse_instance_connection_name(
+    connection_name: str, expected: ConnectionName
+) -> None:
+    """
+    Test that _parse_instance_connection_name works correctly on
+    normal instance connection names and domain-scoped projects.
+    """
+    assert expected == _parse_instance_connection_name(connection_name)
+
+
+def test_parse_instance_connection_name_bad_conn_name() -> None:
+    """
+    Tests that ValueError is thrown for bad instance connection names.
+    """
+    with pytest.raises(ValueError):
+        _parse_instance_connection_name("project:instance")  # missing region

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 import asyncio
 import datetime
-from typing import Tuple
 
 from aiohttp import ClientResponseError
 from aiohttp import RequestInfo
@@ -31,7 +30,6 @@ from google.cloud.sql.connector.client import CloudSQLClient
 from google.cloud.sql.connector.connection_info import ConnectionInfo
 from google.cloud.sql.connector.exceptions import AutoIAMAuthNotSupported
 from google.cloud.sql.connector.exceptions import CloudSQLIPTypeError
-from google.cloud.sql.connector.instance import _parse_instance_connection_name
 from google.cloud.sql.connector.instance import RefreshAheadCache
 from google.cloud.sql.connector.rate_limiter import AsyncRateLimiter
 from google.cloud.sql.connector.refresh_utils import _is_valid
@@ -41,34 +39,6 @@ from google.cloud.sql.connector.utils import generate_keys
 @pytest.fixture
 def test_rate_limiter() -> AsyncRateLimiter:
     return AsyncRateLimiter(max_capacity=1, rate=1 / 2)
-
-
-@pytest.mark.parametrize(
-    "connection_name, expected",
-    [
-        ("project:region:instance", ("project", "region", "instance")),
-        (
-            "domain-prefix:project:region:instance",
-            ("domain-prefix:project", "region", "instance"),
-        ),
-    ],
-)
-def test_parse_instance_connection_name(
-    connection_name: str, expected: Tuple[str, str, str]
-) -> None:
-    """
-    Test that _parse_instance_connection_name works correctly on
-    normal instance connection names and domain-scoped projects.
-    """
-    assert expected == _parse_instance_connection_name(connection_name)
-
-
-def test_parse_instance_connection_name_bad_conn_name() -> None:
-    """
-    Tests that ValueError is thrown for bad instance connection names.
-    """
-    with pytest.raises(ValueError):
-        _parse_instance_connection_name("project:instance")  # missing region
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_pg8000.py
+++ b/tests/unit/test_pg8000.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from functools import partial
 from typing import Any
 

--- a/tests/unit/test_pymysql.py
+++ b/tests/unit/test_pymysql.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from functools import partial
 import ssl
 from typing import Any

--- a/tests/unit/test_pytds.py
+++ b/tests/unit/test_pytds.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from functools import partial
 import platform
 from typing import Any

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import asyncio
 
 import pytest  # noqa F401 Needed to run the tests

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import pytest  # noqa F401 Needed to run the tests
 
 from google.cloud.sql.connector import utils


### PR DESCRIPTION
This PR refactors all instance connection name related code into
its own file `connection_name.py`.

It introduces the `ConnectionName` class which will make tracking
if a DNS name was given to the Connector easier in the future.

This change also aligns the Python Connector more closely to its
Go counterpart's [`conn_name.go`](https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/blob/b228ed7c737467f29b99fff8074bc754b3ce2e81/instance/conn_name.go) for easier maintainability.

Related to #1169 