### PR TITLE
test: round backoff in exponential backoff tests

### DIFF
--- a/tests/unit/test_refresh_utils.py
+++ b/tests/unit/test_refresh_utils.py
@@ -168,7 +168,7 @@ def test_exponential_backoff(attempt: int, low: int, high: int) -> None:
     """
     Test _exponential_backoff produces times (in ms) in the proper range.
     """
-    backoff = _exponential_backoff(attempt)
+    backoff = round(_exponential_backoff(attempt))
     assert backoff >= low
     assert backoff <= high
 


### PR DESCRIPTION
We have seen the backoff value be microseconds below the low value causing test failures.

```
FAILED tests/unit/test_refresh_utils.py::test_exponential_backoff[0-324-524] - assert 323.97999248703616 >= 324
```

Rounding the answer to the nearest millisecond value will reduce flaky test.

Closes https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/issues/1160