### PR TITLE
feat: improve aiohttp client error messages

### DIFF
--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -136,6 +136,7 @@ class CloudSQLClient:
                 message = ret_dict.get("error", {}).get("message")
                 if message:
                     resp.reason = message
+        # skip, raise_for_status will catch all errors in finally block
         except Exception:
             pass
         finally:
@@ -216,6 +217,7 @@ class CloudSQLClient:
                 message = ret_dict.get("error", {}).get("message")
                 if message:
                     resp.reason = message
+        # skip, raise_for_status will catch all errors in finally block
         except Exception:
             pass
         finally:

--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -128,8 +128,19 @@ class CloudSQLClient:
         resp = await self._client.get(url, headers=headers)
         if resp.status >= 500:
             resp = await retry_50x(self._client.get, url, headers=headers)
-        resp.raise_for_status()
-        ret_dict = await resp.json()
+        # try to get response json for better error message
+        try:
+            ret_dict = await resp.json()
+            print(ret_dict)
+            if resp.status >= 400:
+                # if detailed error message is in json response, use as message
+                message = ret_dict.get("error", {}).get("message")
+                if message:
+                    resp.reason = message
+        except Exception:
+            pass
+        finally:
+            resp.raise_for_status()
 
         if ret_dict["region"] != region:
             raise ValueError(
@@ -198,8 +209,18 @@ class CloudSQLClient:
         resp = await self._client.post(url, headers=headers, json=data)
         if resp.status >= 500:
             resp = await retry_50x(self._client.post, url, headers=headers, json=data)
-        resp.raise_for_status()
-        ret_dict = await resp.json()
+        # try to get response json for better error message
+        try:
+            ret_dict = await resp.json()
+            if resp.status >= 400:
+                # if detailed error message is in json response, use as message
+                message = ret_dict.get("error", {}).get("message")
+                if message:
+                    resp.reason = message
+        except Exception:
+            pass
+        finally:
+            resp.raise_for_status()
 
         ephemeral_cert: str = ret_dict["ephemeralCert"]["cert"]
 

--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -132,7 +132,7 @@ class CloudSQLClient:
         try:
             ret_dict = await resp.json()
             if resp.status >= 400:
-                # if detailed error message is in json response, use as message
+                # if detailed error message is in json response, use as error message
                 message = ret_dict.get("error", {}).get("message")
                 if message:
                     resp.reason = message
@@ -213,7 +213,7 @@ class CloudSQLClient:
         try:
             ret_dict = await resp.json()
             if resp.status >= 400:
-                # if detailed error message is in json response, use as message
+                # if detailed error message is in json response, use as error message
                 message = ret_dict.get("error", {}).get("message")
                 if message:
                     resp.reason = message

--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -131,7 +131,6 @@ class CloudSQLClient:
         # try to get response json for better error message
         try:
             ret_dict = await resp.json()
-            print(ret_dict)
             if resp.status >= 400:
                 # if detailed error message is in json response, use as message
                 message = ret_dict.get("error", {}).get("message")

--- a/google/cloud/sql/connector/instance.py
+++ b/google/cloud/sql/connector/instance.py
@@ -22,8 +22,6 @@ from datetime import timedelta
 from datetime import timezone
 import logging
 
-import aiohttp
-
 from google.cloud.sql.connector.client import CloudSQLClient
 from google.cloud.sql.connector.connection_info import ConnectionInfo
 from google.cloud.sql.connector.connection_name import _parse_instance_connection_name
@@ -127,15 +125,6 @@ class RefreshAheadCache:
                 f"['{self._conn_name}']: Current certificate "
                 f"expiration = {connection_info.expiration.isoformat()}"
             )
-
-        except aiohttp.ClientResponseError as e:
-            logger.debug(
-                f"['{self._conn_name}']: Connection info "
-                f"refresh operation failed: {str(e)}"
-            )
-            if e.status == 403:
-                e.message = "Forbidden: Authenticated IAM principal does not seem authorized to make API request. Verify 'Cloud SQL Admin API' is enabled within your GCP project and 'Cloud SQL Client' role has been granted to IAM principal."
-            raise
 
         except Exception as e:
             logger.debug(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -143,7 +143,6 @@ async def test_CloudSQLClient_user_agent(
     await client.close()
 
 
-@pytest.mark.asyncio
 async def test_cloud_sql_error_messages_get_metadata(
     fake_credentials: Credentials,
 ) -> None:
@@ -182,7 +181,6 @@ async def test_cloud_sql_error_messages_get_metadata(
             await client.close()
 
 
-@pytest.mark.asyncio
 async def test_cloud_sql_error_messages_get_ephemeral(
     fake_credentials: Credentials,
 ) -> None:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -169,11 +169,11 @@ async def test_cloud_sql_error_messages_get_metadata(
             payload=resp_body,
             repeat=True,
         )
-        with pytest.raises(ClientResponseError) as e:
+        with pytest.raises(ClientResponseError) as exc_info:
             await client._get_metadata("my-project", "my-region", "my-instance")
-            assert e.status == 403
+            assert exc_info.status == 403
             assert (
-                e.message
+                exc_info.message
                 == "Cloud SQL Admin API has not been used in project 123456789 before or it is disabled"
             )
         await client.close()
@@ -205,8 +205,8 @@ async def test_cloud_sql_error_messages_get_ephemeral(
             payload=resp_body,
             repeat=True,
         )
-        with pytest.raises(ClientResponseError) as e:
+        with pytest.raises(ClientResponseError) as exc_info:
             await client._get_ephemeral("my-project", "my-instance", "my-key")
-            assert e.status == 404
-            assert e.message == "The Cloud SQL instance does not exist."
+            assert exc_info.status == 404
+            assert exc_info.message == "The Cloud SQL instance does not exist."
         await client.close()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -169,16 +169,14 @@ async def test_cloud_sql_error_messages_get_metadata(
             payload=resp_body,
             repeat=True,
         )
-        try:
+        with pytest.raises(ClientResponseError) as e:
             await client._get_metadata("my-project", "my-region", "my-instance")
-        except ClientResponseError as e:
             assert e.status == 403
             assert (
                 e.message
                 == "Cloud SQL Admin API has not been used in project 123456789 before or it is disabled"
             )
-        finally:
-            await client.close()
+        await client.close()
 
 
 async def test_cloud_sql_error_messages_get_ephemeral(
@@ -207,10 +205,8 @@ async def test_cloud_sql_error_messages_get_ephemeral(
             payload=resp_body,
             repeat=True,
         )
-        try:
+        with pytest.raises(ClientResponseError) as e:
             await client._get_ephemeral("my-project", "my-instance", "my-key")
-        except ClientResponseError as e:
             assert e.status == 404
             assert e.message == "The Cloud SQL instance does not exist."
-        finally:
-            await client.close()
+        await client.close()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -179,6 +179,35 @@ async def test_cloud_sql_error_messages_get_metadata(
         await client.close()
 
 
+async def test_get_metadata_error_parsing_json(
+    fake_credentials: Credentials,
+) -> None:
+    """
+    Test that aiohttp default error messages are raised when _get_metadata gets
+    a bad JSON response.
+    """
+    # mock Cloud SQL Admin API calls with exceptions
+    client = CloudSQLClient(
+        sqladmin_api_endpoint="https://sqladmin.googleapis.com",
+        quota_project=None,
+        credentials=fake_credentials,
+    )
+    get_url = "https://sqladmin.googleapis.com/sql/v1beta4/projects/my-project/instances/my-instance/connectSettings"
+    resp_body = ["error"]  # invalid JSON
+    with aioresponses() as mocked:
+        mocked.get(
+            get_url,
+            status=403,
+            payload=resp_body,
+            repeat=True,
+        )
+        with pytest.raises(ClientResponseError) as exc_info:
+            await client._get_metadata("my-project", "my-region", "my-instance")
+        assert exc_info.value.status == 403
+        assert exc_info.value.message == "Forbidden"
+        await client.close()
+
+
 async def test_cloud_sql_error_messages_get_ephemeral(
     fake_credentials: Credentials,
 ) -> None:
@@ -209,4 +238,33 @@ async def test_cloud_sql_error_messages_get_ephemeral(
             await client._get_ephemeral("my-project", "my-instance", "my-key")
         assert exc_info.value.status == 404
         assert exc_info.value.message == "The Cloud SQL instance does not exist."
+        await client.close()
+
+
+async def test_get_ephemeral_error_parsing_json(
+    fake_credentials: Credentials,
+) -> None:
+    """
+    Test that aiohttp default error messages are raised when _get_ephemeral gets
+    a bad JSON response.
+    """
+    # mock Cloud SQL Admin API calls with exceptions
+    client = CloudSQLClient(
+        sqladmin_api_endpoint="https://sqladmin.googleapis.com",
+        quota_project=None,
+        credentials=fake_credentials,
+    )
+    post_url = "https://sqladmin.googleapis.com/sql/v1beta4/projects/my-project/instances/my-instance:generateEphemeralCert"
+    resp_body = ["error"]  # invalid JSON
+    with aioresponses() as mocked:
+        mocked.post(
+            post_url,
+            status=404,
+            payload=resp_body,
+            repeat=True,
+        )
+        with pytest.raises(ClientResponseError) as exc_info:
+            await client._get_ephemeral("my-project", "my-instance", "my-key")
+        assert exc_info.value.status == 404
+        assert exc_info.value.message == "Not Found"
         await client.close()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -171,11 +171,11 @@ async def test_cloud_sql_error_messages_get_metadata(
         )
         with pytest.raises(ClientResponseError) as exc_info:
             await client._get_metadata("my-project", "my-region", "my-instance")
-            assert exc_info.status == 403
-            assert (
-                exc_info.message
-                == "Cloud SQL Admin API has not been used in project 123456789 before or it is disabled"
-            )
+        assert exc_info.value.status == 403
+        assert (
+            exc_info.value.message
+            == "Cloud SQL Admin API has not been used in project 123456789 before or it is disabled"
+        )
         await client.close()
 
 
@@ -207,6 +207,6 @@ async def test_cloud_sql_error_messages_get_ephemeral(
         )
         with pytest.raises(ClientResponseError) as exc_info:
             await client._get_ephemeral("my-project", "my-instance", "my-key")
-            assert exc_info.status == 404
-            assert exc_info.message == "The Cloud SQL instance does not exist."
+        assert exc_info.value.status == 404
+        assert exc_info.value.message == "The Cloud SQL instance does not exist."
         await client.close()


### PR DESCRIPTION
By default, `aiohttp` on bad requests will discard response body and
output generic error message in response, `Bad Request`, `Forbidden`, etc.

The Cloud SQL Admin APIs response body contains more detailed error messages.
We need to raise these to the end user for them to be able to resolve common config 
issues on their own.

In https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/pull/362 we caught `403` errors and implemented a custom error message
to point users at the most common config issues, Cloud SQL API not being enabled,
missing `Cloud SQL Client` role etc. However, this was not a catch-all (as noted by #1199) 
and more of a temporary fix.

This PR implements a more robust solution, copying the actual Cloud SQL Admin API
response body's error message to the end user.

> [!NOTE]
> Example common scenario: Calling the Python Connector with a typo in your instance name.

Error Message today:

```
aiohttp.client_exceptions.ClientResponseError: 404, message='Not Found'
```

Error Message after PR:

```
aiohttp.client_exceptions.ClientResponseError: 404, message='The Cloud SQL instance does not exist.'
```

Related https://github.com/aio-libs/aiohttp/issues/4600
I looked into using a custom response class but it seemed over the top
compared to the working approach here.

Closes #477 