### PR TITLE
ci: use black isort profile and update to latest

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -20,7 +20,7 @@ import os
 
 import nox
 
-BLACK_VERSION = "black==23.12.1"
+BLACK_VERSION = "black==24.10.0"
 ISORT_VERSION = "isort==5.13.2"
 
 LINT_PATHS = ["google", "tests", "noxfile.py", "setup.py"]
@@ -50,7 +50,10 @@ def lint(session):
         "--fss",
         "--check-only",
         "--diff",
-        "--profile=google",
+        "--profile=black",
+        "--force-single-line-imports",
+        "--dont-order-by-type",
+        "--single-line-exclusions=typing",
         "-w=88",
         *LINT_PATHS,
     )
@@ -85,7 +88,10 @@ def format(session):
     session.run(
         "isort",
         "--fss",
-        "--profile=google",
+        "--profile=black",
+        "--force-single-line-imports",
+        "--dont-order-by-type",
+        "--single-line-exclusions=typing",
         "-w=88",
         *LINT_PATHS,
     )

--- a/tests/unit/test_connection_name.py
+++ b/tests/unit/test_connection_name.py
@@ -14,13 +14,11 @@
 
 import pytest  # noqa F401 Needed to run the tests
 
-# fmt: off
+from google.cloud.sql.connector.connection_name import (
+    _parse_connection_name_with_domain_name,
+)
 from google.cloud.sql.connector.connection_name import _parse_connection_name
-from google.cloud.sql.connector.connection_name import \
-    _parse_connection_name_with_domain_name
 from google.cloud.sql.connector.connection_name import ConnectionName
-
-# fmt: on
 
 
 def test_ConnectionName() -> None:


### PR DESCRIPTION
We use both `isort` and `black` formatter's as part of our lint job.

`isort` has [preset profiles](https://pycqa.github.io/isort/docs/configuration/profiles.html), we were using `google` previously but it has begun to
cause conflicts with the black formatter, leading to lint job failures.

Instead, we can use the `black` profile for isort and then manually toggle the other
flags to match the `google` profile.