### PR TITLE
chore: remove type annotations for Enums

### DIFF
--- a/google/cloud/sql/connector/enums.py
+++ b/google/cloud/sql/connector/enums.py
@@ -14,12 +14,13 @@
 
 from __future__ import annotations
 
-from enum import StrEnum
+from enum import Enum
 
 from google.cloud.sql.connector.exceptions import IncompatibleDriverError
 
 
-class RefreshStrategy(StrEnum):
+# TODO: Replace Enum with StrEnum when Python 3.11 is minimum supported version
+class RefreshStrategy(Enum):
     LAZY = "LAZY"
     BACKGROUND = "BACKGROUND"
 
@@ -36,7 +37,7 @@ class RefreshStrategy(StrEnum):
         return cls(refresh_strategy.upper())
 
 
-class IPTypes(StrEnum):
+class IPTypes(Enum):
     PUBLIC = "PRIMARY"
     PRIVATE = "PRIVATE"
     PSC = "PSC"
@@ -56,7 +57,7 @@ class IPTypes(StrEnum):
         return cls(ip_type_str.upper())
 
 
-class DriverMapping(StrEnum):
+class DriverMapping(Enum):
     """Maps a given database driver to it's corresponding database engine."""
 
     ASYNCPG = "POSTGRES"

--- a/google/cloud/sql/connector/enums.py
+++ b/google/cloud/sql/connector/enums.py
@@ -14,14 +14,14 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
 from google.cloud.sql.connector.exceptions import IncompatibleDriverError
 
 
-class RefreshStrategy(Enum):
-    LAZY: str = "LAZY"
-    BACKGROUND: str = "BACKGROUND"
+class RefreshStrategy(StrEnum):
+    LAZY = "LAZY"
+    BACKGROUND = "BACKGROUND"
 
     @classmethod
     def _missing_(cls, value: object) -> None:
@@ -36,10 +36,10 @@ class RefreshStrategy(Enum):
         return cls(refresh_strategy.upper())
 
 
-class IPTypes(Enum):
-    PUBLIC: str = "PRIMARY"
-    PRIVATE: str = "PRIVATE"
-    PSC: str = "PSC"
+class IPTypes(StrEnum):
+    PUBLIC = "PRIMARY"
+    PRIVATE = "PRIVATE"
+    PSC = "PSC"
 
     @classmethod
     def _missing_(cls, value: object) -> None:
@@ -56,7 +56,7 @@ class IPTypes(Enum):
         return cls(ip_type_str.upper())
 
 
-class DriverMapping(Enum):
+class DriverMapping(StrEnum):
     """Maps a given database driver to it's corresponding database engine."""
 
     ASYNCPG = "POSTGRES"


### PR DESCRIPTION
Lint job is complaining:

```
google/cloud/sql/connector/enums.py:23: error: Enum members must be left unannotated  [misc]
```

Enums should not be type hinted.

Since our Enums are of type `str` we should be using [`enum.StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum)
but it was only added in Python 3.11. Added a `TODO` for the future.