### PR TITLE
feat: add support for `GOOGLE_CLOUD_UNIVERSE_DOMAIN` env var

### DIFF
--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 from functools import partial
 import logging
+import os
 from threading import Thread
 from types import TracebackType
 from typing import Any, Optional, Union
@@ -171,7 +172,11 @@ class Connector:
         if isinstance(ip_type, str):
             ip_type = IPTypes._from_str(ip_type)
         self._ip_type = ip_type
-        self._universe_domain = universe_domain
+        # check for universe domain arg and then env var
+        if universe_domain:
+            self._universe_domain = universe_domain
+        else:
+            self._universe_domain = os.environ.get("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
         # construct service endpoint for Cloud SQL Admin API calls
         if not sqladmin_api_endpoint:
             self._sqladmin_api_endpoint = (

--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -176,7 +176,7 @@ class Connector:
         if universe_domain:
             self._universe_domain = universe_domain
         else:
-            self._universe_domain = os.environ.get("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
+            self._universe_domain = os.environ.get("GOOGLE_CLOUD_UNIVERSE_DOMAIN")  # type: ignore
         # construct service endpoint for Cloud SQL Admin API calls
         if not sqladmin_api_endpoint:
             self._sqladmin_api_endpoint = (


### PR DESCRIPTION
Add support for `universe_domain` to be set via the `GOOGLE_CLOUD_UNIVERSE_DOMAIN` env var.

This will allow zero code changes to support non-GDU environments, instead users can set the env var.

Order of operations for setting universe domain will be as follows:

1. Use `universe_domain` argument passed to `Connector()`
2. Use `GOOGLE_CLOUD_UNIVERSE_DOMAIN` env var
3. Use default `"googleapis.com"`

Fixes #1217 