### PR TITLE
feat: add support for `GOOGLE_CLOUD_QUOTA_PROJECT` env var

### DIFF
--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -165,13 +165,17 @@ class Connector:
         # set default params for connections
         self._timeout = timeout
         self._enable_iam_auth = enable_iam_auth
-        self._quota_project = quota_project
         self._user_agent = user_agent
         self._resolver = resolver()
         # if ip_type is str, convert to IPTypes enum
         if isinstance(ip_type, str):
             ip_type = IPTypes._from_str(ip_type)
         self._ip_type = ip_type
+        # check for quota project arg and then env var
+        if quota_project:
+            self._quota_project = quota_project
+        else:
+            self._quota_project = os.environ.get("GOOGLE_CLOUD_QUOTA_PROJECT")  # type: ignore
         # check for universe domain arg and then env var
         if universe_domain:
             self._universe_domain = universe_domain

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -451,3 +451,20 @@ def test_configured_universe_domain_env_var(
         assert connector._sqladmin_api_endpoint == f"https://sqladmin.{universe_domain}"
     # unset env var
     del os.environ["GOOGLE_CLOUD_UNIVERSE_DOMAIN"]
+
+
+def test_configured_quota_project_env_var(
+    fake_credentials: Credentials,
+) -> None:
+    """Test that configured quota project succeeds with quota project
+    set via GOOGLE_CLOUD_QUOTA_PROJECT env var.
+    """
+    quota_project = "my-cool-project"
+    # set environment variable
+    os.environ["GOOGLE_CLOUD_QUOTA_PROJECT"] = quota_project
+    # Note: we are not passing quota_project arg, env var should set it
+    with Connector(credentials=fake_credentials) as connector:
+        # test quota project was configured
+        assert connector._quota_project == quota_project
+    # unset env var
+    del os.environ["GOOGLE_CLOUD_QUOTA_PROJECT"]


### PR DESCRIPTION
Add support for `quota_project` to be set via the `GOOGLE_CLOUD_QUOTA_PROJECT` env var.

Order of operations for setting quota project will be as follows:

1. Use `quota_project` argument passed to `Connector()`
2. Use `GOOGLE_CLOUD_QUOTA_PROJECT` env var
3. Set default to `None` (project set in environment)

Fixes #1229 