### PR TITLE
build: update release.sh to not use setup.py

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -25,5 +25,5 @@ export PYTHONUNBUFFERED=1
 # Move into the package, build the distribution and upload.
 TWINE_PASSWORD=$(cat "${KOKORO_KEYSTORE_DIR}/73713_google-cloud-pypi-token-keystore-3")
 cd github/cloud-sql-python-connector
-python3 setup.py sdist bdist_wheel
+python3 -m build --wheel
 twine upload --username __token__ --password "${TWINE_PASSWORD}" dist/*


### PR DESCRIPTION
In #1230 we moved package off of `setup.py` and over to `pyproject.toml`

Forgot a spot to update in `release.sh` which references `setup.py` which no longer exists.

Related to #1230 