### PR TITLE
refactor: Use new ConnectSettings.DnsNames field to validate the server TLS certificate. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ venv
 .python-version
 cloud_sql_python_connector.egg-info/
 dist/
+.idea
+.coverage
+sponge_log.xml

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -66,6 +66,28 @@ async def test_get_metadata_with_psc(fake_client: CloudSQLClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_metadata_legacy_dns_with_psc(fake_client: CloudSQLClient) -> None:
+    """
+    Test _get_metadata returns successfully with PSC IP type.
+    """
+    # set PSC to enabled on test instance
+    fake_client.instance.psc_enabled = True
+    fake_client.instance.legacy_dns_name = True
+    resp = await fake_client._get_metadata(
+        "test-project",
+        "test-region",
+        "test-instance",
+    )
+    assert resp["database_version"] == "POSTGRES_15"
+    assert resp["ip_addresses"] == {
+        "PRIMARY": "127.0.0.1",
+        "PRIVATE": "10.0.0.1",
+        "PSC": "abcde.12345.us-central1.sql.goog",
+    }
+    assert isinstance(resp["server_ca_cert"], str)
+
+
+@pytest.mark.asyncio
 async def test_get_ephemeral(fake_client: CloudSQLClient) -> None:
     """
     Test _get_ephemeral returns successfully.


### PR DESCRIPTION
When the connector is configured with a DNS name, or if the Cloud SQL Instance reports that it has a DNS Name,
the connector will use standard TLS hostname validation when checking the server certificate. Now, the server's
TLS certificate must contain a SAN record with the instance's DNS name.

The ConnectSettings API added a field dns_names which contains all of the valid DNS names for
an instance.

See also: https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/954