### PR TITLE
docs: use lambda over getconn func

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ import sqlalchemy
 # initialize Connector object
 connector = Connector()
 
-# create connection pool using Connector.connect as SQLAlchemy creator arg
+# initialize SQLAlchemy connection pool with Connector
 pool = sqlalchemy.create_engine(
     "mysql+pymysql://",
     creator=lambda: connector.connect(

--- a/tests/system/test_asyncpg_connection.py
+++ b/tests/system/test_asyncpg_connection.py
@@ -78,21 +78,17 @@ async def create_sqlalchemy_engine(
         loop=loop, refresh_strategy=refresh_strategy, resolver=resolver
     )
 
-    async def getconn() -> asyncpg.Connection:
-        conn: asyncpg.Connection = await connector.connect_async(
+    # create SQLAlchemy connection pool
+    engine = sqlalchemy.ext.asyncio.create_async_engine(
+        "postgresql+asyncpg://",
+        async_creator=lambda: connector.connect_async(
             instance_connection_name,
             "asyncpg",
             user=user,
             password=password,
             db=db,
             ip_type="public",  # can also be "private" or "psc"
-        )
-        return conn
-
-    # create SQLAlchemy connection pool
-    engine = sqlalchemy.ext.asyncio.create_async_engine(
-        "postgresql+asyncpg://",
-        async_creator=getconn,
+        ),
         execution_options={"isolation_level": "AUTOCOMMIT"},
     )
     return engine, connector

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -20,7 +20,6 @@ import os
 # [START cloud_sql_connector_postgres_pg8000]
 from typing import Union
 
-import pg8000
 import sqlalchemy
 
 from google.cloud.sql.connector import Connector
@@ -77,21 +76,17 @@ def create_sqlalchemy_engine(
     """
     connector = Connector(refresh_strategy=refresh_strategy, resolver=resolver)
 
-    def getconn() -> pg8000.dbapi.Connection:
-        conn: pg8000.dbapi.Connection = connector.connect(
+    # create SQLAlchemy connection pool
+    engine = sqlalchemy.create_engine(
+        "postgresql+pg8000://",
+        creator=lambda: connector.connect(
             instance_connection_name,
             "pg8000",
             user=user,
             password=password,
             db=db,
             ip_type="public",  # can also be "private" or "psc"
-        )
-        return conn
-
-    # create SQLAlchemy connection pool
-    engine = sqlalchemy.create_engine(
-        "postgresql+pg8000://",
-        creator=getconn,
+        ),
     )
     return engine, connector
 

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -17,7 +17,6 @@ limitations under the License.
 from datetime import datetime
 import os
 
-import pg8000
 import sqlalchemy
 
 from google.cloud.sql.connector import Connector
@@ -63,21 +62,17 @@ def create_sqlalchemy_engine(
     """
     connector = Connector(refresh_strategy=refresh_strategy)
 
-    def getconn() -> pg8000.dbapi.Connection:
-        conn: pg8000.dbapi.Connection = connector.connect(
+    # create SQLAlchemy connection pool
+    engine = sqlalchemy.create_engine(
+        "postgresql+pg8000://",
+        creator=lambda: connector.connect(
             instance_connection_name,
             "pg8000",
             user=user,
             db=db,
             ip_type="public",  # can also be "private" or "psc"
             enable_iam_auth=True,
-        )
-        return conn
-
-    # create SQLAlchemy connection pool
-    engine = sqlalchemy.create_engine(
-        "postgresql+pg8000://",
-        creator=getconn,
+        ),
     )
     return engine, connector
 

--- a/tests/system/test_pymysql_connection.py
+++ b/tests/system/test_pymysql_connection.py
@@ -18,7 +18,6 @@ from datetime import datetime
 import os
 
 # [START cloud_sql_connector_mysql_pymysql]
-import pymysql
 import sqlalchemy
 
 from google.cloud.sql.connector import Connector
@@ -67,21 +66,17 @@ def create_sqlalchemy_engine(
     """
     connector = Connector(refresh_strategy=refresh_strategy)
 
-    def getconn() -> pymysql.Connection:
-        conn: pymysql.Connection = connector.connect(
+    # create SQLAlchemy connection pool
+    engine = sqlalchemy.create_engine(
+        "mysql+pymysql://",
+        creator=lambda: connector.connect(
             instance_connection_name,
             "pymysql",
             user=user,
             password=password,
             db=db,
             ip_type="public",  # can also be "private" or "psc"
-        )
-        return conn
-
-    # create SQLAlchemy connection pool
-    engine = sqlalchemy.create_engine(
-        "mysql+pymysql://",
-        creator=getconn,
+        ),
     )
     return engine, connector
 

--- a/tests/system/test_pymysql_iam_auth.py
+++ b/tests/system/test_pymysql_iam_auth.py
@@ -17,7 +17,6 @@ limitations under the License.
 from datetime import datetime
 import os
 
-import pymysql
 import sqlalchemy
 
 from google.cloud.sql.connector import Connector
@@ -63,21 +62,17 @@ def create_sqlalchemy_engine(
     """
     connector = Connector(refresh_strategy=refresh_strategy)
 
-    def getconn() -> pymysql.Connection:
-        conn: pymysql.Connection = connector.connect(
+    # create SQLAlchemy connection pool
+    engine = sqlalchemy.create_engine(
+        "mysql+pymysql://",
+        creator=lambda: connector.connect(
             instance_connection_name,
             "pymysql",
             user=user,
             db=db,
             ip_type="public",  # can also be "private" or "psc"
             enable_iam_auth=True,
-        )
-        return conn
-
-    # create SQLAlchemy connection pool
-    engine = sqlalchemy.create_engine(
-        "mysql+pymysql://",
-        creator=getconn,
+        ),
     )
     return engine, connector
 

--- a/tests/system/test_pytds_connection.py
+++ b/tests/system/test_pytds_connection.py
@@ -17,7 +17,6 @@ limitations under the License.
 import os
 
 # [START cloud_sql_connector_mysql_pytds]
-import pytds
 import sqlalchemy
 
 from google.cloud.sql.connector import Connector
@@ -65,21 +64,17 @@ def create_sqlalchemy_engine(
     """
     connector = Connector(refresh_strategy=refresh_strategy)
 
-    def getconn() -> pytds.Connection:
-        conn: pytds.Connection = connector.connect(
+    # create SQLAlchemy connection pool
+    engine = sqlalchemy.create_engine(
+        "mssql+pytds://",
+        creator=lambda: connector.connect(
             instance_connection_name,
             "pytds",
             user=user,
             password=password,
             db=db,
             ip_type="public",  # can also be "private" or "psc"
-        )
-        return conn
-
-    # create SQLAlchemy connection pool
-    engine = sqlalchemy.create_engine(
-        "mssql+pytds://",
-        creator=getconn,
+        ),
     )
     return engine, connector
 


### PR DESCRIPTION
Update README and integration tests to be more pythonic by using `lambda`
over intermediate `getconn` function.

Reduces code required and is more readable.

Instead of using `getconn`:

```python
def getconn() -> pymysql.connections.Connection:
    conn: pymysql.connections.Connection = connector.connect(
        "project:region:instance",
        "pymysql",
        user="my-user",
        password="my-password",
        db="my-db-name"
    )
    return conn

pool = sqlalchemy.create_engine(
    "mysql+pymysql://",
    creator=getconn,
)
```

We can simplify it using a `lambda`:

```python
pool = sqlalchemy.create_engine(
    "mysql+pymysql://",
    creator=lambda: connector.connect(
        "project:region:instance",
        "pymysql",
        user="my-user",
        password="my-password",
        db="my-db-name"
    ),
)
```