### PR TITLE
test: remove test_connector_with_credentials system test

### DIFF
--- a/tests/system/test_connector_object.py
+++ b/tests/system/test_connector_object.py
@@ -20,7 +20,6 @@ import datetime
 import os
 from threading import Thread
 
-import google.auth
 import pymysql
 import pytest
 import sqlalchemy
@@ -48,20 +47,6 @@ def init_connection_engine(
         execution_options={"isolation_level": "AUTOCOMMIT"},
     )
     return pool
-
-
-def test_connector_with_credentials() -> None:
-    """Test Connector object connection with credentials loaded from file."""
-    credentials, _ = google.auth.load_credentials_from_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    with Connector(credentials=credentials) as connector:
-        pool = init_connection_engine(connector)
-
-        with pool.connect() as conn:
-            result = conn.execute(sqlalchemy.text("SELECT 1")).fetchone()
-            assert isinstance(result[0], int)
-            assert result[0] == 1
 
 
 def test_multiple_connectors() -> None:


### PR DESCRIPTION
Removing test_connector_with_credentials from tests/system/test_connector_object.py as unit tests already cover the credential tests

Reference bug: b/396351603