### PR TITLE
test: update ip type for connectors

### DIFF
--- a/tests/system/test_asyncpg_connection.py
+++ b/tests/system/test_asyncpg_connection.py
@@ -32,7 +32,7 @@ async def create_sqlalchemy_engine(
     user: str,
     password: str,
     db: str,
-    ip_type: str,
+    ip_type: str = "public",
     refresh_strategy: str = "background",
     resolver: Union[type[DefaultResolver], type[DnsResolver]] = DefaultResolver,
 ) -> tuple[sqlalchemy.ext.asyncio.engine.AsyncEngine, Connector]:
@@ -65,7 +65,7 @@ async def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance.
+            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -90,7 +90,7 @@ async def create_sqlalchemy_engine(
             user=user,
             password=password,
             db=db,
-            ip_type=ip_type,
+            ip_type=ip_type,  # can be "public", "private" or "psc"
         ),
         execution_options={"isolation_level": "AUTOCOMMIT"},
     )
@@ -102,7 +102,7 @@ async def create_asyncpg_pool(
     user: str,
     password: str,
     db: str,
-    ip_type: str,
+    ip_type: str = "public",
     refresh_strategy: str = "background",
 ) -> tuple[asyncpg.Pool, Connector]:
     """Creates a native asyncpg connection pool for a Cloud SQL instance and
@@ -133,7 +133,7 @@ async def create_asyncpg_pool(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance.
+            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -151,7 +151,7 @@ async def create_asyncpg_pool(
             user=user,
             password=password,
             db=db,
-            ip_type=ip_type,
+            ip_type=ip_type,  # can be "public", "private" or "psc"
             **kwargs,
         )
         return conn
@@ -167,7 +167,7 @@ async def test_sqlalchemy_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     pool, connector = await create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type
@@ -186,7 +186,7 @@ async def test_lazy_sqlalchemy_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     pool, connector = await create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type, "lazy"
@@ -205,7 +205,7 @@ async def test_custom_SAN_with_dns_sqlalchemy_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_CUSTOMER_CAS_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     pool, connector = await create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type, resolver=DnsResolver
@@ -224,7 +224,7 @@ async def test_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     pool, connector = await create_asyncpg_pool(
         inst_conn_name, user, password, db, ip_type
@@ -243,7 +243,7 @@ async def test_lazy_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     pool, connector = await create_asyncpg_pool(
         inst_conn_name, user, password, db, ip_type, "lazy"

--- a/tests/system/test_asyncpg_connection.py
+++ b/tests/system/test_asyncpg_connection.py
@@ -167,9 +167,11 @@ async def test_sqlalchemy_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
-    pool, connector = await create_sqlalchemy_engine(inst_conn_name, user, password, db, ip_type)
+    pool, connector = await create_sqlalchemy_engine(
+        inst_conn_name, user, password, db, ip_type
+    )
 
     async with pool.connect() as conn:
         res = (await conn.execute(sqlalchemy.text("SELECT 1"))).fetchone()
@@ -184,7 +186,7 @@ async def test_lazy_sqlalchemy_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
     pool, connector = await create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type, "lazy"
@@ -203,10 +205,10 @@ async def test_custom_SAN_with_dns_sqlalchemy_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_CUSTOMER_CAS_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
     pool, connector = await create_sqlalchemy_engine(
-        inst_conn_name, user, password, db, ip_type,resolver=DnsResolver
+        inst_conn_name, user, password, db, ip_type, resolver=DnsResolver
     )
 
     async with pool.connect() as conn:
@@ -222,9 +224,11 @@ async def test_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
-    pool, connector = await create_asyncpg_pool(inst_conn_name, user, password, db, ip_type)
+    pool, connector = await create_asyncpg_pool(
+        inst_conn_name, user, password, db, ip_type
+    )
 
     async with pool.acquire() as conn:
         res = await conn.fetch("SELECT 1")
@@ -239,7 +243,7 @@ async def test_lazy_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
     pool, connector = await create_asyncpg_pool(
         inst_conn_name, user, password, db, ip_type, "lazy"

--- a/tests/system/test_asyncpg_connection.py
+++ b/tests/system/test_asyncpg_connection.py
@@ -151,7 +151,7 @@ async def create_asyncpg_pool(
             user=user,
             password=password,
             db=db,
-            ip_type=ip_type
+            ip_type=ip_type,
             **kwargs,
         )
         return conn

--- a/tests/system/test_asyncpg_connection.py
+++ b/tests/system/test_asyncpg_connection.py
@@ -65,7 +65,8 @@ async def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
+            The IP type of the Cloud SQL instance to connect to. Can be one
+            of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -133,7 +134,8 @@ async def create_asyncpg_pool(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
+            The IP type of the Cloud SQL instance to connect to. Can be one
+            of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid

--- a/tests/system/test_asyncpg_connection.py
+++ b/tests/system/test_asyncpg_connection.py
@@ -87,7 +87,9 @@ async def create_sqlalchemy_engine(
             user=user,
             password=password,
             db=db,
-            ip_type="public",  # can also be "private" or "psc"
+            ip_type=os.environ.get(
+                "IP_TYPE", "public"
+            ),  # can also be "private" or "psc"
         ),
         execution_options={"isolation_level": "AUTOCOMMIT"},
     )
@@ -145,7 +147,9 @@ async def create_asyncpg_pool(
             user=user,
             password=password,
             db=db,
-            ip_type="public",  # can also be "private" or "psc",
+            ip_type=os.environ.get(
+                "IP_TYPE", "public"
+            ),  # can also be "private" or "psc",
             **kwargs,
         )
         return conn

--- a/tests/system/test_asyncpg_connection.py
+++ b/tests/system/test_asyncpg_connection.py
@@ -32,6 +32,7 @@ async def create_sqlalchemy_engine(
     user: str,
     password: str,
     db: str,
+    ip_type: str,
     refresh_strategy: str = "background",
     resolver: Union[type[DefaultResolver], type[DnsResolver]] = DefaultResolver,
 ) -> tuple[sqlalchemy.ext.asyncio.engine.AsyncEngine, Connector]:
@@ -63,6 +64,8 @@ async def create_sqlalchemy_engine(
             The database user's password, e.g., secret-password
         db (str):
             The name of the database, e.g., mydb
+        ip_type (str):
+            The IP type of the Cloud SQL instance.
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -87,9 +90,7 @@ async def create_sqlalchemy_engine(
             user=user,
             password=password,
             db=db,
-            ip_type=os.environ.get(
-                "IP_TYPE", "public"
-            ),  # can also be "private" or "psc"
+            ip_type=ip_type,
         ),
         execution_options={"isolation_level": "AUTOCOMMIT"},
     )
@@ -101,6 +102,7 @@ async def create_asyncpg_pool(
     user: str,
     password: str,
     db: str,
+    ip_type: str,
     refresh_strategy: str = "background",
 ) -> tuple[asyncpg.Pool, Connector]:
     """Creates a native asyncpg connection pool for a Cloud SQL instance and
@@ -130,6 +132,8 @@ async def create_asyncpg_pool(
             The database user's password, e.g., secret-password
         db (str):
             The name of the database, e.g., mydb
+        ip_type (str):
+            The IP type of the Cloud SQL instance.
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -147,9 +151,7 @@ async def create_asyncpg_pool(
             user=user,
             password=password,
             db=db,
-            ip_type=os.environ.get(
-                "IP_TYPE", "public"
-            ),  # can also be "private" or "psc",
+            ip_type=ip_type
             **kwargs,
         )
         return conn
@@ -165,8 +167,9 @@ async def test_sqlalchemy_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
-    pool, connector = await create_sqlalchemy_engine(inst_conn_name, user, password, db)
+    pool, connector = await create_sqlalchemy_engine(inst_conn_name, user, password, db, ip_type)
 
     async with pool.connect() as conn:
         res = (await conn.execute(sqlalchemy.text("SELECT 1"))).fetchone()
@@ -181,9 +184,10 @@ async def test_lazy_sqlalchemy_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
     pool, connector = await create_sqlalchemy_engine(
-        inst_conn_name, user, password, db, "lazy"
+        inst_conn_name, user, password, db, ip_type, "lazy"
     )
 
     async with pool.connect() as conn:
@@ -199,9 +203,10 @@ async def test_custom_SAN_with_dns_sqlalchemy_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_CUSTOMER_CAS_PASS"]
     db = os.environ["POSTGRES_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
     pool, connector = await create_sqlalchemy_engine(
-        inst_conn_name, user, password, db, resolver=DnsResolver
+        inst_conn_name, user, password, db, ip_type,resolver=DnsResolver
     )
 
     async with pool.connect() as conn:
@@ -217,8 +222,9 @@ async def test_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
-    pool, connector = await create_asyncpg_pool(inst_conn_name, user, password, db)
+    pool, connector = await create_asyncpg_pool(inst_conn_name, user, password, db, ip_type)
 
     async with pool.acquire() as conn:
         res = await conn.fetch("SELECT 1")
@@ -233,9 +239,10 @@ async def test_lazy_connection_with_asyncpg() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
     pool, connector = await create_asyncpg_pool(
-        inst_conn_name, user, password, db, "lazy"
+        inst_conn_name, user, password, db, ip_type, "lazy"
     )
 
     async with pool.acquire() as conn:

--- a/tests/system/test_asyncpg_iam_auth.py
+++ b/tests/system/test_asyncpg_iam_auth.py
@@ -71,7 +71,9 @@ async def create_sqlalchemy_engine(
             "asyncpg",
             user=user,
             db=db,
-            ip_type="public",  # can also be "private" or "psc"
+            ip_type=os.environ.get(
+                "IP_TYPE", "public"
+            ),  # can also be "private" or "psc"
             enable_iam_auth=True,
         ),
         execution_options={"isolation_level": "AUTOCOMMIT"},

--- a/tests/system/test_asyncpg_iam_auth.py
+++ b/tests/system/test_asyncpg_iam_auth.py
@@ -87,7 +87,7 @@ async def test_iam_authn_connection_with_asyncpg() -> None:
     inst_conn_name = os.environ["POSTGRES_CONNECTION_NAME"]
     user = os.environ["POSTGRES_IAM_USER"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
     pool, connector = await create_sqlalchemy_engine(inst_conn_name, user, db, ip_type)
 
@@ -103,9 +103,11 @@ async def test_lazy_iam_authn_connection_with_asyncpg() -> None:
     inst_conn_name = os.environ["POSTGRES_CONNECTION_NAME"]
     user = os.environ["POSTGRES_IAM_USER"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
-    pool, connector = await create_sqlalchemy_engine(inst_conn_name, user, db, ip_type, "lazy")
+    pool, connector = await create_sqlalchemy_engine(
+        inst_conn_name, user, db, ip_type, "lazy"
+    )
 
     async with pool.connect() as conn:
         res = (await conn.execute(sqlalchemy.text("SELECT 1"))).fetchone()

--- a/tests/system/test_asyncpg_iam_auth.py
+++ b/tests/system/test_asyncpg_iam_auth.py
@@ -57,7 +57,8 @@ async def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
+            The IP type of the Cloud SQL instance to connect to. Can be one
+            of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid

--- a/tests/system/test_asyncpg_iam_auth.py
+++ b/tests/system/test_asyncpg_iam_auth.py
@@ -27,7 +27,7 @@ async def create_sqlalchemy_engine(
     instance_connection_name: str,
     user: str,
     db: str,
-    ip_type: str,
+    ip_type: str = "public",
     refresh_strategy: str = "background",
 ) -> tuple[sqlalchemy.ext.asyncio.engine.AsyncEngine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
@@ -57,7 +57,7 @@ async def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance.
+            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -74,7 +74,7 @@ async def create_sqlalchemy_engine(
             "asyncpg",
             user=user,
             db=db,
-            ip_type=ip_type,
+            ip_type=ip_type,  # can be "public", "private" or "psc"
             enable_iam_auth=True,
         ),
         execution_options={"isolation_level": "AUTOCOMMIT"},
@@ -87,7 +87,7 @@ async def test_iam_authn_connection_with_asyncpg() -> None:
     inst_conn_name = os.environ["POSTGRES_CONNECTION_NAME"]
     user = os.environ["POSTGRES_IAM_USER"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     pool, connector = await create_sqlalchemy_engine(inst_conn_name, user, db, ip_type)
 
@@ -103,7 +103,7 @@ async def test_lazy_iam_authn_connection_with_asyncpg() -> None:
     inst_conn_name = os.environ["POSTGRES_CONNECTION_NAME"]
     user = os.environ["POSTGRES_IAM_USER"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     pool, connector = await create_sqlalchemy_engine(
         inst_conn_name, user, db, ip_type, "lazy"

--- a/tests/system/test_connector_object.py
+++ b/tests/system/test_connector_object.py
@@ -39,6 +39,9 @@ def init_connection_engine(
             user=os.environ["MYSQL_USER"],
             password=os.environ["MYSQL_PASS"],
             db=os.environ["MYSQL_DB"],
+            ip_type=os.environ.get(
+                "IP_TYPE", "public"
+            ),
         )
         return conn
 

--- a/tests/system/test_connector_object.py
+++ b/tests/system/test_connector_object.py
@@ -39,9 +39,7 @@ def init_connection_engine(
             user=os.environ["MYSQL_USER"],
             password=os.environ["MYSQL_PASS"],
             db=os.environ["MYSQL_DB"],
-            ip_type=os.environ.get(
-                "IP_TYPE", "public"
-            ),
+            ip_type=os.environ.get("IP_TYPE", "public"),
         )
         return conn
 

--- a/tests/system/test_ip_types.py
+++ b/tests/system/test_ip_types.py
@@ -34,7 +34,7 @@ def init_connection_engine(
         conn: pymysql.connections.Connection = connector.connect(
             os.environ["MYSQL_CONNECTION_NAME"],
             "pymysql",
-            ip_type=ip_type,
+            ip_type=ip_type,  # can be "public", "private" or "psc"
             user=os.environ["MYSQL_USER"],
             password=os.environ["MYSQL_PASS"],
             db=os.environ["MYSQL_DB"],

--- a/tests/system/test_ip_types.py
+++ b/tests/system/test_ip_types.py
@@ -34,7 +34,7 @@ def init_connection_engine(
         conn: pymysql.connections.Connection = connector.connect(
             os.environ["MYSQL_CONNECTION_NAME"],
             "pymysql",
-            ip_type=ip_type,  # can be "public", "private" or "psc"
+            ip_type=ip_type,
             user=os.environ["MYSQL_USER"],
             password=os.environ["MYSQL_PASS"],
             db=os.environ["MYSQL_DB"],

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -32,7 +32,7 @@ def create_sqlalchemy_engine(
     user: str,
     password: str,
     db: str,
-    ip_type: str,
+    ip_type: str = "public",
     refresh_strategy: str = "background",
     resolver: Union[type[DefaultResolver], type[DnsResolver]] = DefaultResolver,
 ) -> tuple[sqlalchemy.engine.Engine, Connector]:
@@ -66,7 +66,7 @@ def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance.
+            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -88,7 +88,7 @@ def create_sqlalchemy_engine(
             user=user,
             password=password,
             db=db,
-            ip_type=ip_type,
+            ip_type=ip_type,  # can be "public", "private" or "psc"
         ),
     )
     return engine, connector
@@ -103,7 +103,7 @@ def test_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type
@@ -122,7 +122,7 @@ def test_lazy_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type, "lazy"
@@ -141,7 +141,7 @@ def test_CAS_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_CAS_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type
@@ -160,7 +160,7 @@ def test_customer_managed_CAS_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_CUSTOMER_CAS_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type
@@ -179,7 +179,7 @@ def test_custom_SAN_with_dns_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_CUSTOMER_CAS_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type, resolver=DnsResolver

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -103,9 +103,11 @@ def test_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db, ip_type)
+    engine, connector = create_sqlalchemy_engine(
+        inst_conn_name, user, password, db, ip_type
+    )
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()
@@ -120,7 +122,7 @@ def test_lazy_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type, "lazy"
@@ -139,9 +141,11 @@ def test_CAS_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_CAS_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db, ip_type)
+    engine, connector = create_sqlalchemy_engine(
+        inst_conn_name, user, password, db, ip_type
+    )
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()
@@ -156,9 +160,11 @@ def test_customer_managed_CAS_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_CUSTOMER_CAS_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db, ip_type)
+    engine, connector = create_sqlalchemy_engine(
+        inst_conn_name, user, password, db, ip_type
+    )
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()
@@ -173,7 +179,7 @@ def test_custom_SAN_with_dns_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_CUSTOMER_CAS_PASS"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type, resolver=DnsResolver

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -32,6 +32,7 @@ def create_sqlalchemy_engine(
     user: str,
     password: str,
     db: str,
+    ip_type: str,
     refresh_strategy: str = "background",
     resolver: Union[type[DefaultResolver], type[DnsResolver]] = DefaultResolver,
 ) -> tuple[sqlalchemy.engine.Engine, Connector]:
@@ -64,6 +65,8 @@ def create_sqlalchemy_engine(
             The database user's password, e.g., secret-password
         db (str):
             The name of the database, e.g., mydb
+        ip_type (str):
+            The IP type of the Cloud SQL instance.
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -85,9 +88,7 @@ def create_sqlalchemy_engine(
             user=user,
             password=password,
             db=db,
-            ip_type=os.environ.get(
-                "IP_TYPE", "public"
-            ),  # can also be "private" or "psc"
+            ip_type=ip_type,
         ),
     )
     return engine, connector
@@ -102,8 +103,9 @@ def test_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db)
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db, ip_type)
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()
@@ -118,9 +120,10 @@ def test_lazy_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_PASS"]
     db = os.environ["POSTGRES_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
     engine, connector = create_sqlalchemy_engine(
-        inst_conn_name, user, password, db, "lazy"
+        inst_conn_name, user, password, db, ip_type, "lazy"
     )
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
@@ -136,8 +139,9 @@ def test_CAS_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_CAS_PASS"]
     db = os.environ["POSTGRES_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db)
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db, ip_type)
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()
@@ -152,8 +156,9 @@ def test_customer_managed_CAS_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_CUSTOMER_CAS_PASS"]
     db = os.environ["POSTGRES_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db)
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db, ip_type)
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()
@@ -168,9 +173,10 @@ def test_custom_SAN_with_dns_pg8000_connection() -> None:
     user = os.environ["POSTGRES_USER"]
     password = os.environ["POSTGRES_CUSTOMER_CAS_PASS"]
     db = os.environ["POSTGRES_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
     engine, connector = create_sqlalchemy_engine(
-        inst_conn_name, user, password, db, resolver=DnsResolver
+        inst_conn_name, user, password, db, ip_type, resolver=DnsResolver
     )
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -85,7 +85,9 @@ def create_sqlalchemy_engine(
             user=user,
             password=password,
             db=db,
-            ip_type="public",  # can also be "private" or "psc"
+            ip_type=os.environ.get(
+                "IP_TYPE", "public"
+            ),  # can also be "private" or "psc"
         ),
     )
     return engine, connector

--- a/tests/system/test_pg8000_connection.py
+++ b/tests/system/test_pg8000_connection.py
@@ -66,7 +66,8 @@ def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
+            The IP type of the Cloud SQL instance to connect to. Can be one
+            of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -26,7 +26,7 @@ def create_sqlalchemy_engine(
     instance_connection_name: str,
     user: str,
     db: str,
-    ip_type: str,
+    ip_type: str = "public",
     refresh_strategy: str = "background",
 ) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
@@ -57,7 +57,7 @@ def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance.
+            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -73,7 +73,7 @@ def create_sqlalchemy_engine(
             "pg8000",
             user=user,
             db=db,
-            ip_type=ip_type,
+            ip_type=ip_type,  # can be "public", "private" or "psc"
             enable_iam_auth=True,
         ),
     )
@@ -85,7 +85,7 @@ def test_pg8000_iam_authn_connection() -> None:
     inst_conn_name = os.environ["POSTGRES_CONNECTION_NAME"]
     user = os.environ["POSTGRES_IAM_USER"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, ip_type)
     with engine.connect() as conn:
@@ -101,7 +101,7 @@ def test_lazy_pg8000_iam_authn_connection() -> None:
     inst_conn_name = os.environ["POSTGRES_CONNECTION_NAME"]
     user = os.environ["POSTGRES_IAM_USER"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, db, ip_type, "lazy"

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -57,7 +57,8 @@ def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
+            The IP type of the Cloud SQL instance to connect to. Can be one
+            of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -85,7 +85,7 @@ def test_pg8000_iam_authn_connection() -> None:
     inst_conn_name = os.environ["POSTGRES_CONNECTION_NAME"]
     user = os.environ["POSTGRES_IAM_USER"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
     engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, ip_type)
     with engine.connect() as conn:
@@ -101,9 +101,11 @@ def test_lazy_pg8000_iam_authn_connection() -> None:
     inst_conn_name = os.environ["POSTGRES_CONNECTION_NAME"]
     user = os.environ["POSTGRES_IAM_USER"]
     db = os.environ["POSTGRES_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, ip_type, "lazy")
+    engine, connector = create_sqlalchemy_engine(
+        inst_conn_name, user, db, ip_type, "lazy"
+    )
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -70,7 +70,9 @@ def create_sqlalchemy_engine(
             "pg8000",
             user=user,
             db=db,
-            ip_type="public",  # can also be "private" or "psc"
+            ip_type=os.environ.get(
+                "IP_TYPE", "public"
+            ),  # can also be "private" or "psc"
             enable_iam_auth=True,
         ),
     )

--- a/tests/system/test_pg8000_iam_auth.py
+++ b/tests/system/test_pg8000_iam_auth.py
@@ -26,6 +26,7 @@ def create_sqlalchemy_engine(
     instance_connection_name: str,
     user: str,
     db: str,
+    ip_type: str,
     refresh_strategy: str = "background",
 ) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
@@ -55,6 +56,8 @@ def create_sqlalchemy_engine(
             e.g., my-email@test.com, service-account@project-id.iam
         db (str):
             The name of the database, e.g., mydb
+        ip_type (str):
+            The IP type of the Cloud SQL instance.
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -70,9 +73,7 @@ def create_sqlalchemy_engine(
             "pg8000",
             user=user,
             db=db,
-            ip_type=os.environ.get(
-                "IP_TYPE", "public"
-            ),  # can also be "private" or "psc"
+            ip_type=ip_type,
             enable_iam_auth=True,
         ),
     )
@@ -84,8 +85,9 @@ def test_pg8000_iam_authn_connection() -> None:
     inst_conn_name = os.environ["POSTGRES_CONNECTION_NAME"]
     user = os.environ["POSTGRES_IAM_USER"]
     db = os.environ["POSTGRES_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db)
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, ip_type)
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()
@@ -99,8 +101,9 @@ def test_lazy_pg8000_iam_authn_connection() -> None:
     inst_conn_name = os.environ["POSTGRES_CONNECTION_NAME"]
     user = os.environ["POSTGRES_IAM_USER"]
     db = os.environ["POSTGRES_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, "lazy")
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, ip_type, "lazy")
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()

--- a/tests/system/test_pymysql_connection.py
+++ b/tests/system/test_pymysql_connection.py
@@ -28,7 +28,7 @@ def create_sqlalchemy_engine(
     user: str,
     password: str,
     db: str,
-    ip_type: str,
+    ip_type: str = "public",
     refresh_strategy: str = "background",
 ) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
@@ -61,7 +61,7 @@ def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance.
+            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -78,7 +78,7 @@ def create_sqlalchemy_engine(
             user=user,
             password=password,
             db=db,
-            ip_type=ip_type,
+            ip_type=ip_type,  # can be "public", "private" or "psc"
         ),
     )
     return engine, connector
@@ -93,7 +93,7 @@ def test_pymysql_connection() -> None:
     user = os.environ["MYSQL_USER"]
     password = os.environ["MYSQL_PASS"]
     db = os.environ["MYSQL_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type
@@ -112,7 +112,7 @@ def test_lazy_pymysql_connection() -> None:
     user = os.environ["MYSQL_USER"]
     password = os.environ["MYSQL_PASS"]
     db = os.environ["MYSQL_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type, "lazy"

--- a/tests/system/test_pymysql_connection.py
+++ b/tests/system/test_pymysql_connection.py
@@ -61,7 +61,8 @@ def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
+            The IP type of the Cloud SQL instance to connect to. Can be one
+            of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid

--- a/tests/system/test_pymysql_connection.py
+++ b/tests/system/test_pymysql_connection.py
@@ -93,9 +93,11 @@ def test_pymysql_connection() -> None:
     user = os.environ["MYSQL_USER"]
     password = os.environ["MYSQL_PASS"]
     db = os.environ["MYSQL_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db, ip_type)
+    engine, connector = create_sqlalchemy_engine(
+        inst_conn_name, user, password, db, ip_type
+    )
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()
@@ -110,7 +112,7 @@ def test_lazy_pymysql_connection() -> None:
     user = os.environ["MYSQL_USER"]
     password = os.environ["MYSQL_PASS"]
     db = os.environ["MYSQL_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type, "lazy"

--- a/tests/system/test_pymysql_connection.py
+++ b/tests/system/test_pymysql_connection.py
@@ -28,6 +28,7 @@ def create_sqlalchemy_engine(
     user: str,
     password: str,
     db: str,
+    ip_type: str,
     refresh_strategy: str = "background",
 ) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
@@ -59,6 +60,8 @@ def create_sqlalchemy_engine(
             The database user's password, e.g., secret-password
         db (str):
             The name of the database, e.g., mydb
+        ip_type (str):
+            The IP type of the Cloud SQL instance.
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -75,9 +78,7 @@ def create_sqlalchemy_engine(
             user=user,
             password=password,
             db=db,
-            ip_type=os.environ.get(
-                "IP_TYPE", "public"
-            ),  # can also be "private" or "psc"
+            ip_type=ip_type,
         ),
     )
     return engine, connector
@@ -92,8 +93,9 @@ def test_pymysql_connection() -> None:
     user = os.environ["MYSQL_USER"]
     password = os.environ["MYSQL_PASS"]
     db = os.environ["MYSQL_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db)
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db, ip_type)
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()
@@ -108,9 +110,10 @@ def test_lazy_pymysql_connection() -> None:
     user = os.environ["MYSQL_USER"]
     password = os.environ["MYSQL_PASS"]
     db = os.environ["MYSQL_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
     engine, connector = create_sqlalchemy_engine(
-        inst_conn_name, user, password, db, "lazy"
+        inst_conn_name, user, password, db, ip_type, "lazy"
     )
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()

--- a/tests/system/test_pymysql_connection.py
+++ b/tests/system/test_pymysql_connection.py
@@ -75,7 +75,9 @@ def create_sqlalchemy_engine(
             user=user,
             password=password,
             db=db,
-            ip_type="public",  # can also be "private" or "psc"
+            ip_type=os.environ.get(
+                "IP_TYPE", "public"
+            ),  # can also be "private" or "psc"
         ),
     )
     return engine, connector

--- a/tests/system/test_pymysql_iam_auth.py
+++ b/tests/system/test_pymysql_iam_auth.py
@@ -26,7 +26,7 @@ def create_sqlalchemy_engine(
     instance_connection_name: str,
     user: str,
     db: str,
-    ip_type: str,
+    ip_type: str = "public",
     refresh_strategy: str = "background",
 ) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
@@ -57,7 +57,7 @@ def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance.
+            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -73,7 +73,7 @@ def create_sqlalchemy_engine(
             "pymysql",
             user=user,
             db=db,
-            ip_type=ip_type,
+            ip_type=ip_type,  # can be "public", "private" or "psc"
             enable_iam_auth=True,
         ),
     )
@@ -85,7 +85,7 @@ def test_pymysql_iam_authn_connection() -> None:
     inst_conn_name = os.environ["MYSQL_CONNECTION_NAME"]
     user = os.environ["MYSQL_IAM_USER"]
     db = os.environ["MYSQL_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, ip_type)
     with engine.connect() as conn:
@@ -101,7 +101,7 @@ def test_lazy_pymysql_iam_authn_connection() -> None:
     inst_conn_name = os.environ["MYSQL_CONNECTION_NAME"]
     user = os.environ["MYSQL_IAM_USER"]
     db = os.environ["MYSQL_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, db, ip_type, "lazy"

--- a/tests/system/test_pymysql_iam_auth.py
+++ b/tests/system/test_pymysql_iam_auth.py
@@ -70,7 +70,9 @@ def create_sqlalchemy_engine(
             "pymysql",
             user=user,
             db=db,
-            ip_type="public",  # can also be "private" or "psc"
+            ip_type=os.environ.get(
+                "IP_TYPE", "public"
+            ),  # can also be "private" or "psc"
             enable_iam_auth=True,
         ),
     )

--- a/tests/system/test_pymysql_iam_auth.py
+++ b/tests/system/test_pymysql_iam_auth.py
@@ -85,7 +85,7 @@ def test_pymysql_iam_authn_connection() -> None:
     inst_conn_name = os.environ["MYSQL_CONNECTION_NAME"]
     user = os.environ["MYSQL_IAM_USER"]
     db = os.environ["MYSQL_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
     engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, ip_type)
     with engine.connect() as conn:
@@ -101,9 +101,11 @@ def test_lazy_pymysql_iam_authn_connection() -> None:
     inst_conn_name = os.environ["MYSQL_CONNECTION_NAME"]
     user = os.environ["MYSQL_IAM_USER"]
     db = os.environ["MYSQL_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, ip_type, "lazy")
+    engine, connector = create_sqlalchemy_engine(
+        inst_conn_name, user, db, ip_type, "lazy"
+    )
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()

--- a/tests/system/test_pymysql_iam_auth.py
+++ b/tests/system/test_pymysql_iam_auth.py
@@ -26,6 +26,7 @@ def create_sqlalchemy_engine(
     instance_connection_name: str,
     user: str,
     db: str,
+    ip_type: str,
     refresh_strategy: str = "background",
 ) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
@@ -55,6 +56,8 @@ def create_sqlalchemy_engine(
             e.g., my-email@test.com -> my-email
         db (str):
             The name of the database, e.g., mydb
+        ip_type (str):
+            The IP type of the Cloud SQL instance.
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -70,9 +73,7 @@ def create_sqlalchemy_engine(
             "pymysql",
             user=user,
             db=db,
-            ip_type=os.environ.get(
-                "IP_TYPE", "public"
-            ),  # can also be "private" or "psc"
+            ip_type=ip_type,
             enable_iam_auth=True,
         ),
     )
@@ -84,8 +85,9 @@ def test_pymysql_iam_authn_connection() -> None:
     inst_conn_name = os.environ["MYSQL_CONNECTION_NAME"]
     user = os.environ["MYSQL_IAM_USER"]
     db = os.environ["MYSQL_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db)
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, ip_type)
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()
@@ -99,8 +101,9 @@ def test_lazy_pymysql_iam_authn_connection() -> None:
     inst_conn_name = os.environ["MYSQL_CONNECTION_NAME"]
     user = os.environ["MYSQL_IAM_USER"]
     db = os.environ["MYSQL_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, "lazy")
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, db, ip_type, "lazy")
     with engine.connect() as conn:
         time = conn.execute(sqlalchemy.text("SELECT NOW()")).fetchone()
         conn.commit()

--- a/tests/system/test_pymysql_iam_auth.py
+++ b/tests/system/test_pymysql_iam_auth.py
@@ -57,7 +57,8 @@ def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
+            The IP type of the Cloud SQL instance to connect to. Can be one
+            of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid

--- a/tests/system/test_pytds_connection.py
+++ b/tests/system/test_pytds_connection.py
@@ -59,7 +59,8 @@ def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
+            The IP type of the Cloud SQL instance to connect to. Can be one
+            of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid

--- a/tests/system/test_pytds_connection.py
+++ b/tests/system/test_pytds_connection.py
@@ -91,9 +91,11 @@ def test_pytds_connection() -> None:
     user = os.environ["SQLSERVER_USER"]
     password = os.environ["SQLSERVER_PASS"]
     db = os.environ["SQLSERVER_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db, ip_type)
+    engine, connector = create_sqlalchemy_engine(
+        inst_conn_name, user, password, db, ip_type
+    )
     with engine.connect() as conn:
         res = conn.execute(sqlalchemy.text("SELECT 1")).fetchone()
         conn.commit()
@@ -107,7 +109,7 @@ def test_lazy_pytds_connection() -> None:
     user = os.environ["SQLSERVER_USER"]
     password = os.environ["SQLSERVER_PASS"]
     db = os.environ["SQLSERVER_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type, "lazy"

--- a/tests/system/test_pytds_connection.py
+++ b/tests/system/test_pytds_connection.py
@@ -27,7 +27,7 @@ def create_sqlalchemy_engine(
     user: str,
     password: str,
     db: str,
-    ip_type: str,
+    ip_type: str = "public",
     refresh_strategy: str = "background",
 ) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
@@ -59,7 +59,7 @@ def create_sqlalchemy_engine(
         db (str):
             The name of the database, e.g., mydb
         ip_type (str):
-            The IP type of the Cloud SQL instance.
+            The IP type of the Cloud SQL instance. Can be one of "public", "private", or "psc".
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -76,7 +76,7 @@ def create_sqlalchemy_engine(
             user=user,
             password=password,
             db=db,
-            ip_type=ip_type,  # can also be "private" or "psc"
+            ip_type=ip_type,  # can be "public", "private" or "psc"
         ),
     )
     return engine, connector
@@ -91,7 +91,7 @@ def test_pytds_connection() -> None:
     user = os.environ["SQLSERVER_USER"]
     password = os.environ["SQLSERVER_PASS"]
     db = os.environ["SQLSERVER_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type
@@ -109,7 +109,7 @@ def test_lazy_pytds_connection() -> None:
     user = os.environ["SQLSERVER_USER"]
     password = os.environ["SQLSERVER_PASS"]
     db = os.environ["SQLSERVER_DB"]
-    ip_type = os.environ.get("IP_TYPE", "public")  # can be "public", "private" or "psc"
+    ip_type = os.environ.get("IP_TYPE", "public")
 
     engine, connector = create_sqlalchemy_engine(
         inst_conn_name, user, password, db, ip_type, "lazy"

--- a/tests/system/test_pytds_connection.py
+++ b/tests/system/test_pytds_connection.py
@@ -27,6 +27,7 @@ def create_sqlalchemy_engine(
     user: str,
     password: str,
     db: str,
+    ip_type: str,
     refresh_strategy: str = "background",
 ) -> tuple[sqlalchemy.engine.Engine, Connector]:
     """Creates a connection pool for a Cloud SQL instance and returns the pool
@@ -57,6 +58,8 @@ def create_sqlalchemy_engine(
             The database user's password, e.g., secret-password
         db (str):
             The name of the database, e.g., mydb
+        ip_type (str):
+            The IP type of the Cloud SQL instance.
         refresh_strategy (Optional[str]):
             Refresh strategy for the Cloud SQL Connector. Can be one of "lazy"
             or "background". For serverless environments use "lazy" to avoid
@@ -73,9 +76,7 @@ def create_sqlalchemy_engine(
             user=user,
             password=password,
             db=db,
-            ip_type=os.environ.get(
-                "IP_TYPE", "public"
-            ),  # can also be "private" or "psc"
+            ip_type=ip_type,  # can also be "private" or "psc"
         ),
     )
     return engine, connector
@@ -90,8 +91,9 @@ def test_pytds_connection() -> None:
     user = os.environ["SQLSERVER_USER"]
     password = os.environ["SQLSERVER_PASS"]
     db = os.environ["SQLSERVER_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
-    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db)
+    engine, connector = create_sqlalchemy_engine(inst_conn_name, user, password, db, ip_type)
     with engine.connect() as conn:
         res = conn.execute(sqlalchemy.text("SELECT 1")).fetchone()
         conn.commit()
@@ -105,9 +107,10 @@ def test_lazy_pytds_connection() -> None:
     user = os.environ["SQLSERVER_USER"]
     password = os.environ["SQLSERVER_PASS"]
     db = os.environ["SQLSERVER_DB"]
+    ip_type = os.environ.get("IP_TYPE", "public") # can be "public", "private" or "psc"
 
     engine, connector = create_sqlalchemy_engine(
-        inst_conn_name, user, password, db, "lazy"
+        inst_conn_name, user, password, db, ip_type, "lazy"
     )
     with engine.connect() as conn:
         res = conn.execute(sqlalchemy.text("SELECT 1")).fetchone()

--- a/tests/system/test_pytds_connection.py
+++ b/tests/system/test_pytds_connection.py
@@ -73,7 +73,9 @@ def create_sqlalchemy_engine(
             user=user,
             password=password,
             db=db,
-            ip_type="public",  # can also be "private" or "psc"
+            ip_type=os.environ.get(
+                "IP_TYPE", "public"
+            ),  # can also be "private" or "psc"
         ),
     )
     return engine, connector


### PR DESCRIPTION
Updates ip_type parameter to use environment variable - "IP_TYPE" to enable private IP tests. The default still remains "public"

Reference: b/396351603