### PR TITLE
build: configure cloudbuild for psa tests

### DIFF
--- a/.cl/cloudbuild.yaml
+++ b/.cl/cloudbuild.yaml
@@ -14,7 +14,7 @@
 
 steps:
   - id: run integration tests for python version 3.9
-    name: python:${_PYTHON_3.9}
+    name: python:${_PYTHON_3_9}
     entrypoint: bash
     env: 
       - "IP_TYPE=private"
@@ -23,10 +23,10 @@ steps:
       - "-c"
       - |
         pip install nox
-        nox -s system-${_PYTHON_3.9}
+        nox -s system-${_PYTHON_3_9}
     waitFor: ["-"]
   - id: run integration tests for python version 3.13
-    name: python:${_PYTHON_3.13}
+    name: python:${_PYTHON_3_13}
     entrypoint: bash
     env: 
       - "IP_TYPE=private"
@@ -35,7 +35,7 @@ steps:
       - "-c"
       - |
         pip install nox
-        nox -s system-${_PYTHON_3.13}
+        nox -s system-${_PYTHON_3_13}
     waitFor: ["-"]
 availableSecrets:
   secretManager:
@@ -78,8 +78,8 @@ availableSecrets:
   - versionName: 'projects/$PROJECT_ID/secrets/SQLSERVER_DB/versions/latest'
     env: 'SQLSERVER_DB'
 substitutions:
-  _PYTHON_3.13: '3.13'
-  _PYTHON_3.9: '3.9'
+  _PYTHON_3_13: '3.13'
+  _PYTHON_3_9: '3.9'
   
 options:
   dynamicSubstitutions: true

--- a/.cl/cloudbuild.yaml
+++ b/.cl/cloudbuild.yaml
@@ -1,0 +1,88 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - id: run integration tests for python version 3.9
+    name: python:${_PYTHON_3.9}
+    entrypoint: bash
+    env: 
+      - "IP_TYPE=private"
+    secretEnv: ["MYSQL_CONNECTION_NAME", "MYSQL_USER", "MYSQL_IAM_USER", "MYSQL_PASS", "MYSQL_DB", "POSTGRES_CONNECTION_NAME", "POSTGRES_USER", "POSTGRES_IAM_USER", "POSTGRES_PASS", "POSTGRES_DB",  "POSTGRES_CAS_CONNECTION_NAME", "POSTGRES_CAS_PASS", "POSTGRES_CUSTOMER_CAS_CONNECTION_NAME", "POSTGRES_CUSTOMER_CAS_PASS", "POSTGRES_CUSTOMER_CAS_PASS_VALID_DOMAIN_NAME","SQLSERVER_CONNECTION_NAME", "SQLSERVER_USER", "SQLSERVER_PASS", "SQLSERVER_DB"]
+    args:
+      - "-c"
+      - |
+        pip install nox
+        nox -s system-${_PYTHON_3.9}
+    waitFor: ["-"]
+  - id: run integration tests for python version 3.13
+    name: python:${_PYTHON_3.13}
+    entrypoint: bash
+    env: 
+      - "IP_TYPE=private"
+    secretEnv: ["MYSQL_CONNECTION_NAME", "MYSQL_USER", "MYSQL_IAM_USER", "MYSQL_PASS", "MYSQL_DB", "POSTGRES_CONNECTION_NAME", "POSTGRES_USER", "POSTGRES_IAM_USER", "POSTGRES_PASS", "POSTGRES_DB",  "POSTGRES_CAS_CONNECTION_NAME", "POSTGRES_CAS_PASS", "POSTGRES_CUSTOMER_CAS_CONNECTION_NAME", "POSTGRES_CUSTOMER_CAS_PASS", "POSTGRES_CUSTOMER_CAS_PASS_VALID_DOMAIN_NAME","SQLSERVER_CONNECTION_NAME", "SQLSERVER_USER", "SQLSERVER_PASS", "SQLSERVER_DB"]
+    args:
+      - "-c"
+      - |
+        pip install nox
+        nox -s system-${_PYTHON_3.13}
+    waitFor: ["-"]
+availableSecrets:
+  secretManager:
+  - versionName: 'projects/$PROJECT_ID/secrets/MYSQL_CONNECTION_NAME/versions/latest'
+    env: 'MYSQL_CONNECTION_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/MYSQL_USER/versions/latest'
+    env: 'MYSQL_USER'
+  - versionName: 'projects/$PROJECT_ID/secrets/CLOUD_BUILD_MYSQL_IAM_USER/versions/latest'
+    env: 'MYSQL_IAM_USER'
+  - versionName: 'projects/$PROJECT_ID/secrets/MYSQL_PASS/versions/latest'
+    env: 'MYSQL_PASS'
+  - versionName: 'projects/$PROJECT_ID/secrets/MYSQL_DB/versions/latest'
+    env: 'MYSQL_DB'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CONNECTION_NAME/versions/latest'
+    env: 'POSTGRES_CONNECTION_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_USER/versions/latest'
+    env: 'POSTGRES_USER'
+  - versionName: 'projects/$PROJECT_ID/secrets/CLOUD_BUILD_POSTGRES_IAM_USER/versions/latest'
+    env: 'POSTGRES_IAM_USER'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_PASS/versions/latest'
+    env: 'POSTGRES_PASS'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_DB/versions/latest'
+    env: 'POSTGRES_DB'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CAS_CONNECTION_NAME/versions/latest'
+    env: 'POSTGRES_CAS_CONNECTION_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CAS_PASS/versions/latest'
+    env: 'POSTGRES_CAS_PASS'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CUSTOMER_CAS_CONNECTION_NAME/versions/latest'
+    env: 'POSTGRES_CUSTOMER_CAS_CONNECTION_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CUSTOMER_CAS_PASS/versions/latest'
+    env: 'POSTGRES_CUSTOMER_CAS_PASS'
+  - versionName: 'projects/$PROJECT_ID/secrets/POSTGRES_CUSTOMER_CAS_PASS_VALID_DOMAIN_NAME/versions/latest'
+    env: 'POSTGRES_CUSTOMER_CAS_PASS_VALID_DOMAIN_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/SQLSERVER_CONNECTION_NAME/versions/latest'
+    env: 'SQLSERVER_CONNECTION_NAME'
+  - versionName: 'projects/$PROJECT_ID/secrets/SQLSERVER_USER/versions/latest'
+    env: 'SQLSERVER_USER'
+  - versionName: 'projects/$PROJECT_ID/secrets/SQLSERVER_PASS/versions/latest'
+    env: 'SQLSERVER_PASS'
+  - versionName: 'projects/$PROJECT_ID/secrets/SQLSERVER_DB/versions/latest'
+    env: 'SQLSERVER_DB'
+substitutions:
+  _PYTHON_3.13: '3.13'
+  _PYTHON_3.9: '3.9'
+  
+options:
+  dynamicSubstitutions: true
+  pool:
+    name: ${_POOL_NAME}
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
This PR enables private IP tests for Cloud SQL instances with the help of Cloud Build private pool

Introduced a new environment variable - IP_TYPE which is set as "private" for PSA tests in the cloudbuild.yaml file

reference: b/396351603