### PR TITLE
test: update server used for tests to use SSL/TLS

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,11 +17,15 @@ limitations under the License.
 import asyncio
 import os
 import socket
+import ssl
 from threading import Thread
-from typing import Any, AsyncGenerator, Generator
+from typing import Any, AsyncGenerator
 
+from aiofiles.tempfile import TemporaryDirectory
 from aiohttp import web
+from cryptography.hazmat.primitives import serialization
 import pytest  # noqa F401 Needed to run the tests
+from unit.mocks import create_ssl_context  # type: ignore
 from unit.mocks import FakeCredentials  # type: ignore
 from unit.mocks import FakeCSQLInstance  # type: ignore
 
@@ -29,6 +33,7 @@ from google.cloud.sql.connector.client import CloudSQLClient
 from google.cloud.sql.connector.connection_name import ConnectionName
 from google.cloud.sql.connector.instance import RefreshAheadCache
 from google.cloud.sql.connector.utils import generate_keys
+from google.cloud.sql.connector.utils import write_to_file
 
 SCOPES = ["https://www.googleapis.com/auth/sqlservice.admin"]
 
@@ -79,25 +84,58 @@ def fake_credentials() -> FakeCredentials:
     return FakeCredentials()
 
 
-def mock_server(server_sock: socket.socket) -> None:
-    """Create mock server listening on specified ip_address and port."""
+async def start_proxy_server(instance: FakeCSQLInstance) -> None:
+    """Run local proxy server capable of performing mTLS"""
     ip_address = "127.0.0.1"
     port = 3307
-    server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    server_sock.bind((ip_address, port))
-    server_sock.listen(0)
-    server_sock.accept()
+    # create socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        # create SSL/TLS context
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.minimum_version = ssl.TLSVersion.TLSv1_3
+        # tmpdir and its contents are automatically deleted after the CA cert
+        # and cert chain are loaded into the SSLcontext. The values
+        # need to be written to files in order to be loaded by the SSLContext
+        server_key_bytes = instance.server_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        async with TemporaryDirectory() as tmpdir:
+            server_filename, _, key_filename = await write_to_file(
+                tmpdir, instance.server_cert_pem, "", server_key_bytes
+            )
+            context.load_cert_chain(server_filename, key_filename)
+        # bind socket to Cloud SQL proxy server port on localhost
+        sock.bind((ip_address, port))
+        # listen for incoming connections
+        sock.listen(5)
+
+        with context.wrap_socket(sock, server_side=True) as ssock:
+            while True:
+                conn, _ = ssock.accept()
+                conn.close()
+
+
+@pytest.fixture(scope="session")
+def proxy_server(fake_instance: FakeCSQLInstance) -> None:
+    """Run local proxy server capable of performing mTLS"""
+    thread = Thread(
+        target=asyncio.run,
+        args=(
+            start_proxy_server(
+                fake_instance,
+            ),
+        ),
+        daemon=True,
+    )
+    thread.start()
+    thread.join(1.0)  # add a delay to allow the proxy server to start
 
 
 @pytest.fixture
-def server() -> Generator:
-    """Create thread with server listening on proper port"""
-    server_sock = socket.socket()
-    thread = Thread(target=mock_server, args=(server_sock,), daemon=True)
-    thread.start()
-    yield thread
-    server_sock.close()
-    thread.join()
+async def context(fake_instance: FakeCSQLInstance) -> ssl.SSLContext:
+    return await create_ssl_context(fake_instance)
 
 
 @pytest.fixture
@@ -107,7 +145,7 @@ def kwargs() -> Any:
     return kwargs
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fake_instance() -> FakeCSQLInstance:
     return FakeCSQLInstance()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,8 @@ async def start_proxy_server(instance: FakeCSQLInstance) -> None:
                 tmpdir, instance.server_cert_pem, "", server_key_bytes
             )
             context.load_cert_chain(server_filename, key_filename)
+        # allow socket to be re-used
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         # bind socket to Cloud SQL proxy server port on localhost
         sock.bind((ip_address, port))
         # listen for incoming connections

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -1,4 +1,4 @@
-""" "
+"""
 Copyright 2022 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -186,17 +186,18 @@ async def test_RefreshAheadCache_close(cache: RefreshAheadCache) -> None:
 @pytest.mark.asyncio
 async def test_perform_refresh(
     cache: RefreshAheadCache,
-    fake_instance: mocks.FakeCSQLInstance,
 ) -> None:
     """
     Test that _perform_refresh returns valid ConnectionInfo object.
     """
     instance_metadata = await cache._perform_refresh()
-
     # verify instance metadata object is returned
     assert isinstance(instance_metadata, ConnectionInfo)
     # verify instance metadata expiration
-    assert fake_instance.server_cert.not_valid_after_utc == instance_metadata.expiration
+    assert (
+        cache._client.instance.cert_expiration.replace(microsecond=0)
+        == instance_metadata.expiration
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_pg8000.py
+++ b/tests/unit/test_pg8000.py
@@ -15,26 +15,22 @@ limitations under the License.
 """
 
 import socket
+import ssl
 from typing import Any
 
 from mock import patch
-from mocks import create_ssl_context
 import pytest
 
 from google.cloud.sql.connector.pg8000 import connect
 
 
-@pytest.mark.usefixtures("server")
-@pytest.mark.asyncio
-async def test_pg8000(kwargs: Any) -> None:
+@pytest.mark.usefixtures("proxy_server")
+async def test_pg8000(context: ssl.SSLContext, kwargs: Any) -> None:
     """Test to verify that pg8000 gets to proper connection call."""
     ip_addr = "127.0.0.1"
-    # build ssl.SSLContext
-    context = await create_ssl_context()
     sock = context.wrap_socket(
         socket.create_connection((ip_addr, 3307)),
         server_hostname=ip_addr,
-        do_handshake_on_connect=False,
     )
     with patch("pg8000.dbapi.connect") as mock_connect:
         mock_connect.return_value = True

--- a/tests/unit/test_pymysql.py
+++ b/tests/unit/test_pymysql.py
@@ -19,7 +19,6 @@ import ssl
 from typing import Any
 
 from mock import patch
-from mocks import create_ssl_context
 import pytest
 
 from google.cloud.sql.connector.pymysql import connect as pymysql_connect
@@ -33,17 +32,14 @@ class MockConnection:
         assert isinstance(sock, ssl.SSLSocket)
 
 
-@pytest.mark.usefixtures("server")
+@pytest.mark.usefixtures("proxy_server")
 @pytest.mark.asyncio
-async def test_pymysql(kwargs: Any) -> None:
+async def test_pymysql(context: ssl.SSLContext, kwargs: Any) -> None:
     """Test to verify that pymysql gets to proper connection call."""
     ip_addr = "127.0.0.1"
-    # build ssl.SSLContext
-    context = await create_ssl_context()
     sock = context.wrap_socket(
         socket.create_connection((ip_addr, 3307)),
         server_hostname=ip_addr,
-        do_handshake_on_connect=False,
     )
     kwargs["timeout"] = 30
     with patch("pymysql.Connection") as mock_connect:

--- a/tests/unit/test_pytds.py
+++ b/tests/unit/test_pytds.py
@@ -16,10 +16,10 @@ limitations under the License.
 
 import platform
 import socket
+import ssl
 from typing import Any
 
 from mock import patch
-from mocks import create_ssl_context
 import pytest
 
 from google.cloud.sql.connector.exceptions import PlatformNotSupportedError
@@ -36,17 +36,13 @@ def stub_platform_windows() -> str:
     return "Windows"
 
 
-@pytest.mark.usefixtures("server")
-@pytest.mark.asyncio
-async def test_pytds(kwargs: Any) -> None:
+@pytest.mark.usefixtures("proxy_server")
+async def test_pytds(context: ssl.SSLContext, kwargs: Any) -> None:
     """Test to verify that pytds gets to proper connection call."""
     ip_addr = "127.0.0.1"
-    # build ssl.SSLContext
-    context = await create_ssl_context()
     sock = context.wrap_socket(
         socket.create_connection((ip_addr, 3307)),
         server_hostname=ip_addr,
-        do_handshake_on_connect=False,
     )
 
     with patch("pytds.connect") as mock_connect:
@@ -57,20 +53,16 @@ async def test_pytds(kwargs: Any) -> None:
         assert mock_connect.assert_called_once
 
 
-@pytest.mark.usefixtures("server")
-@pytest.mark.asyncio
-async def test_pytds_platform_error(kwargs: Any) -> None:
+@pytest.mark.usefixtures("proxy_server")
+async def test_pytds_platform_error(context: ssl.SSLContext, kwargs: Any) -> None:
     """Test to verify that pytds.connect throws proper PlatformNotSupportedError."""
     ip_addr = "127.0.0.1"
     # stub operating system to Linux
     setattr(platform, "system", stub_platform_linux)
     assert platform.system() == "Linux"
-    # build ssl.SSLContext
-    context = await create_ssl_context()
     sock = context.wrap_socket(
         socket.create_connection((ip_addr, 3307)),
         server_hostname=ip_addr,
-        do_handshake_on_connect=False,
     )
     # add active_directory_auth to kwargs
     kwargs["active_directory_auth"] = True
@@ -79,9 +71,10 @@ async def test_pytds_platform_error(kwargs: Any) -> None:
         connect(ip_addr, sock, **kwargs)
 
 
-@pytest.mark.usefixtures("server")
-@pytest.mark.asyncio
-async def test_pytds_windows_active_directory_auth(kwargs: Any) -> None:
+@pytest.mark.usefixtures("proxy_server")
+async def test_pytds_windows_active_directory_auth(
+    context: ssl.SSLContext, kwargs: Any
+) -> None:
     """
     Test to verify that pytds gets to connection call on Windows with
     active_directory_auth arg set.
@@ -90,12 +83,9 @@ async def test_pytds_windows_active_directory_auth(kwargs: Any) -> None:
     # stub operating system to Windows
     setattr(platform, "system", stub_platform_windows)
     assert platform.system() == "Windows"
-    # build ssl.SSLContext
-    context = await create_ssl_context()
     sock = context.wrap_socket(
         socket.create_connection((ip_addr, 3307)),
         server_hostname=ip_addr,
-        do_handshake_on_connect=False,
     )
     # add active_directory_auth and server_name to kwargs
     kwargs["active_directory_auth"] = True


### PR DESCRIPTION
This PR improves the local server used for unit tests.

The previous `server` fixture was just a plain socket unable to perform SSL/TLS.
This meant in certain tests we were skipping the SSL/TLS handshake because it
would fail. 

The new `proxy_server` fixture more closely behaves to that of the real Proxy server.
It allows SSL/TLS by loading in the server CA used for testing, the client can then
use the new  `context` fixture to properly use SSL to connect to the server.

This will provide a foundation for testing the metadata exchange which will be
introduced in the near future.