### PR TITLE
chore: add check for closed connector

### DIFF
--- a/google/cloud/sql/connector/connector.py
+++ b/google/cloud/sql/connector/connector.py
@@ -154,6 +154,7 @@ class Connector:
         # connection name string and enable_iam_auth boolean flag
         self._cache: dict[tuple[str, bool], MonitoredCache] = {}
         self._client: Optional[CloudSQLClient] = None
+        self._closed: bool = False
 
         # initialize credentials
         scopes = ["https://www.googleapis.com/auth/sqlservice.admin"]
@@ -280,7 +281,11 @@ class Connector:
                 and then subsequent attempt with IAM database authentication.
             KeyError: Unsupported database driver Must be one of pymysql, asyncpg,
                 pg8000, and pytds.
+            RuntimeError: Connector has been closed. Cannot connect using a closed
+                Connector.
         """
+        if self._closed:
+            raise RuntimeError("Cannot connect using a closed Connector.")
         if self._keys is None:
             self._keys = asyncio.create_task(generate_keys())
         if self._client is None:
@@ -463,6 +468,7 @@ class Connector:
                 self._loop.call_soon_threadsafe(self._loop.stop)
             # wait for thread to finish closing (i.e. loop to stop)
             self._thread.join()
+        self._closed = True
 
     async def close_async(self) -> None:
         """Helper function to cancel the cache's tasks
@@ -470,6 +476,7 @@ class Connector:
         await asyncio.gather(*[cache.close() for cache in self._cache.values()])
         if self._client:
             await self._client.close()
+        self._closed = True
 
 
 async def create_async_connector(


### PR DESCRIPTION
Draft-PR to check if the connector's been closed before trying to connect using the same engine.

1. Throws error if the connector has been closed 
2. Continues to connect otherwise

