### PR TITLE
chore: update code coverage to use proper python version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Calculate base code coverage
         run: |
-          nox --sessions unit-3.10
+          nox --sessions unit-3.13
           coverage report --show-missing
           export CUR_COVER=$(coverage report | awk '$1 == "TOTAL" {print $NF+0}')
           echo "CUR_COVER=$CUR_COVER" >> $GITHUB_ENV
@@ -51,7 +51,7 @@ jobs:
 
       - name: Calculate PR code coverage
         run: |
-          nox --sessions unit-3.10
+          nox --sessions unit-3.13
           coverage report --show-missing
           export PR_COVER=$(coverage report | awk '$1 == "TOTAL" {print $NF+0}')
           echo "PR_COVER=$PR_COVER" >> $GITHUB_ENV


### PR DESCRIPTION
Code coverage check is failing due to not finding a Python 3.10 distribution.

We are using Python 3.13 in the setup-python section of the coverage job but
then running nox with Python 3.10.

https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/blob/27f6de3268605fe9d03913ba351bb754c0c9ff5c/.github/workflows/coverage.yml#L29-L40

Both setup-python and nox should run using same Python version