### PR TITLE
fix: Use either x509.not_valid_after_utc or if it does not exist, x509.not_valid_after

### DIFF
--- a/google/cloud/sql/connector/client.py
+++ b/google/cloud/sql/connector/client.py
@@ -234,7 +234,14 @@ class CloudSQLClient:
         x509 = load_pem_x509_certificate(
             ephemeral_cert.encode("UTF-8"), default_backend()
         )
-        expiration = x509.not_valid_after_utc
+
+        if 'not_valid_after_utc' in x509:
+            expiration = x509.not_valid_after_utc
+        elif 'not_valid_after' in x509:
+            expiration = x509.not_valid_after
+        else:
+            expiration = datetime.MINYEAR
+
         # for IAM authentication OAuth2 token is embedded in cert so it
         # must still be valid for successful connection
         if enable_iam_auth:


### PR DESCRIPTION
Some versions of python do not have a not_valid_after_utc but only contain the not_valid_after field. Update
the python connector to prefer not_valid_after_utc, but gracefully fall back to not_valid_after.