### PR TITLE
feat: Use configured DNS name to lookup instance IP address

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,7 @@ if [[ ! -d venv ]] ; then
   echo "./venv not found. Setting up venv"
   python3 -m venv "$PWD/venv"
 fi
+
 source "$PWD/venv/bin/activate"
 
 if which pip3 ; then
@@ -135,6 +136,10 @@ function write_e2e_env(){
     val=$(gcloud secrets versions access latest --project "$TEST_PROJECT" --secret="$secret_name")
     echo "export $env_var_name='$val'"
   done
+  # Aliases for python e2e tests
+  echo "export POSTGRES_CUSTOMER_CAS_PASS_VALID_DOMAIN_NAME=\"\$POSTGRES_CUSTOMER_CAS_DOMAIN_NAME\""
+  echo "export POSTGRES_IAM_USER=\"\$POSTGRES_USER_IAM\""
+  echo "export MYSQL_IAM_USER=\"\$MYSQL_USER_IAM\""
   } > "$1"
 
 }

--- a/google/cloud/sql/connector/resolver.py
+++ b/google/cloud/sql/connector/resolver.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
+
 import dns.asyncresolver
 
 from google.cloud.sql.connector.connection_name import _is_valid_domain
@@ -52,6 +54,16 @@ class DnsResolver(dns.asyncresolver.Resolver):
                     f"name, got {dns}."
                 )
         return conn_name
+
+    async def resolve_a_record(self, dns: str) -> List[str]:
+        try:
+            # Attempt to query the A records.
+            records = await super().resolve(dns, "A", raise_on_no_answer=True)
+            # return IP addresses as strings
+            return [record.to_text() for record in records]
+        except Exception:
+            # On any error, return empty list
+            return []
 
     async def query_dns(self, dns: str) -> ConnectionName:
         try:


### PR DESCRIPTION
When a custom DNS name is used to connect to a Cloud SQL instance, the dialer should first attempt to resolve the custom DNS name to an IP address and use that for the connection. If the lookup fails, the dialer should fall back to using the IP address from the instance metadata.

Fixes #1362
