### PR TITLE
ci: skip schedule reporter on forks

### DIFF
--- a/.github/workflows/cloud_build_failure_reporter.yml
+++ b/.github/workflows/cloud_build_failure_reporter.yml
@@ -29,6 +29,7 @@ on:
 
 jobs:
   report:
+    if: github.repository == 'GoogleCloudPlatform/cloud-sql-python-connector'
 
     permissions:
       issues: 'write'

--- a/.github/workflows/cloud_build_failure_reporter.yml
+++ b/.github/workflows/cloud_build_failure_reporter.yml
@@ -40,13 +40,15 @@ jobs:
 
     steps:
       - uses: 'actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd' # v8
+        env:
+          TRIGGER_NAMES: ${{ inputs.trigger_names }}
         with:
           script: |-
                   // parse test names
-                  const testNameSubstring = '${{ inputs.trigger_names }}';
+                  const testNameSubstring = process.env.TRIGGER_NAMES || '';
                   const testNameFound = new Map(); //keeps track of whether each test is found
                   testNameSubstring.split(',').forEach(testName => {
-                    testNameFound.set(testName, false); 
+                    testNameFound.set(testName.trim(), false); 
                   });
                   
                   // label for all issues opened by reporter
@@ -173,8 +175,8 @@ jobs:
                   const noTestFound = Array.from(testNameFound.values()).every(value => value === false);
                   if (noTestFound){
                     createOrCommentIssue(
-                      'Missing periodic tests: ${{ inputs.trigger_names }}',
-                      `No periodic test is found for triggers: ${{ inputs.trigger_names }}. Last checked from ${
+                      `Missing periodic tests: ${testNameSubstring}`,
+                      `No periodic test is found for triggers: ${testNameSubstring}. Last checked from ${
                         commits[0].html_url
                       } to ${commits[commits.length - 1].html_url}.`
                     );

--- a/.github/workflows/schedule_reporter.yml
+++ b/.github/workflows/schedule_reporter.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   run_reporter:
+    if: github.repository == 'GoogleCloudPlatform/cloud-sql-python-connector'
     permissions:
       issues: 'write'
       checks: 'read'
@@ -27,3 +28,4 @@ jobs:
     uses: ./.github/workflows/cloud_build_failure_reporter.yml
     with:
       trigger_names: "py-continuous-test-on-merge,py-integration-test-nightly"
+


### PR DESCRIPTION
Skip Schedule Reporter and Cloud Build Failure Reporter workflows on fork repositories to prevent failures caused by disabled GitHub Issues and missing Cloud Build checks.