### PR TITLE
feat: drop support for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ name = "cloud-sql-python-connector"
 authors = [{ name = "Google LLC", email = "googleapis-packages@google.com" }]
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 classifiers = [
     # Should be one of:
@@ -33,11 +33,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
 dependencies = [
@@ -77,7 +77,7 @@ version = { attr = "google.cloud.sql.connector.version.__version__" }
 include = ["google*"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 namespace_packages = true
 ignore_missing_imports = true
 warn_unused_configs = true


### PR DESCRIPTION
per https://github.com/GoogleCloudPlatform/cloud-sql-python-connector/pull/1339